### PR TITLE
feat: improve schema validation handling and lint log levels

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -7,6 +7,11 @@ import build from "../lib/build/index.js";
 import generateMockData from "../lib/generator/mocks.js";
 import generateComponent from "../lib/generator/component.js";
 import validateMockData from "../lib/validator/mocks.js";
+import {
+	getSchemaValidationMode,
+	toSchemaValidationResult,
+	validateSchemas,
+} from "../lib/validator/schemas.js";
 
 /**
  * @param {object} obj
@@ -172,14 +177,44 @@ export const createComponent = async ({ component, only = [], skip = [] }) => {
 
 export const lintComponents = async () => {
 	global.app = await init("api");
-	const promises = [];
+	const mode = getSchemaValidationMode();
+	const components = global.state.routes.filter((route) => route.paths.tpl);
+	const schemaValidation = validateSchemas({
+		components,
+	});
+	const schemaErrorsByComponent = new Map();
 
-	global.state.routes.forEach((route) => {
-		if (route.paths.tpl) {
-			promises.push(
+	schemaValidation.errors.forEach((entry) => {
+		if (!schemaErrorsByComponent.has(entry.component)) {
+			schemaErrorsByComponent.set(entry.component, []);
+		}
+		schemaErrorsByComponent
+			.get(entry.component)
+			.push(toSchemaValidationResult(entry));
+	});
+
+	if (mode === "fail-fast" && schemaValidation.errors.length > 0) {
+		return {
+			success: false,
+			data: getLintComponentErrorsInRouteOrder({
+				components,
+				errorMap: schemaErrorsByComponent,
+			}),
+		};
+	}
+
+	const promises = components
+		.filter((route) => !schemaErrorsByComponent.has(route.paths.dir.short))
+		.map(
+			(route) =>
 				new Promise((resolve) => {
 					getComponentData(route).then((data) => {
-						const validation = validateMockData(route, data || [], true);
+						const validation = validateMockData(
+							route,
+							data || [],
+							true,
+							schemaValidation.validSchemas,
+						);
 
 						resolve({
 							component: route.alias,
@@ -187,13 +222,25 @@ export const lintComponents = async () => {
 						});
 					});
 				}),
-			);
-		}
-	});
+		);
 
 	return await Promise.all(promises)
 		.then((res) => {
-			const errors = res.filter((result) => result?.errors?.length > 0);
+			res.forEach((result) => {
+				if (!result?.errors?.length) {
+					return;
+				}
+				const componentErrors = schemaErrorsByComponent.get(result.component) || [];
+				schemaErrorsByComponent.set(result.component, [
+					...componentErrors,
+					...result.errors,
+				]);
+			});
+
+			const errors = getLintComponentErrorsInRouteOrder({
+				components,
+				errorMap: schemaErrorsByComponent,
+			});
 
 			return {
 				success: errors.length === 0,
@@ -216,8 +263,26 @@ export const lintComponent = async ({ component }) => {
 			message: `The component ${component} does not seem to exist.`,
 		};
 
+	const allSchemaValidation = validateSchemas({
+		components: [componentObject],
+	});
+
+	if (allSchemaValidation.errors.length > 0) {
+		return {
+			success: false,
+			data: allSchemaValidation.errors.map((entry) =>
+				toSchemaValidationResult(entry),
+			),
+		};
+	}
+
 	const data = await getComponentData(componentObject);
-	const errors = validateMockData(componentObject, data, true);
+	const errors = validateMockData(
+		componentObject,
+		data || [],
+		true,
+		allSchemaValidation.validSchemas,
+	);
 
 	return {
 		success: errors === null || errors?.length === 0,
@@ -233,4 +298,27 @@ function getComponentsObject(component) {
 	return global.state.routes.find(
 		(route) => route.paths.dir.short === component,
 	);
+}
+
+/**
+ * @param {object} params
+ * @param {Array<object>} params.components
+ * @param {Map<string, Array<object>>} params.errorMap
+ * @returns {Array<object>}
+ */
+function getLintComponentErrorsInRouteOrder({ components, errorMap }) {
+	return components
+		.map((route) => {
+			const componentErrors = errorMap.get(route.alias) || [];
+
+			if (componentErrors.length === 0) {
+				return null;
+			}
+
+			return {
+				component: route.alias,
+				errors: componentErrors,
+			};
+		})
+		.filter(Boolean);
 }

--- a/docs/cli-commands/linting-mock-data.md
+++ b/docs/cli-commands/linting-mock-data.md
@@ -1,6 +1,6 @@
 # Linting mock data
 
-When linting components, _miyagi_ checks if the JSON schema files are valid and if the mock data fits to the JSON schema file.
+When linting components, _miyagi_ checks if the JSON/YAML schema files are valid and if the mock data fits the schema.
 
 You can either lint all components at once via:
 
@@ -15,5 +15,16 @@ miyagi lint path/to/component
 ```
 
 Please note that when you reference a schema file from another schema file or a mock file from another mock file ([Referencing other mock files](/component-files/mocks/#referencing-other-mock-files)) and the referenced file is invalid, you will get multiple errors reported by _miyagi_ (one for the invalid file and one for the file which includes the invalid file).
+
+Schema warnings are now explicit:
+
+- Missing schema file: component has no schema. If expected, consider adding the component path to `components.ignores`.
+- Parse failure: schema file exists but could not be parsed as JSON/YAML.
+
+You can control lint output noise using `lint.logLevel` in config:
+
+- `error` (default): show errors only
+- `warn`: show errors and warnings
+- `info`: show errors, warnings, and info/success messages
 
 If you lint all components, the process will properly be exited with error code 1. This can be helpful if you want to include the linting in your CI e.g..

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -28,12 +28,12 @@ default:
 
 ```json
 {
-	"files": [],
-	"prefixes": {
-		"color": "color",
-		"typo": "typo",
-		"spacing": "spacing"
-	}
+  "files": [],
+  "prefixes": {
+    "color": "color",
+    "typo": "typo",
+    "spacing": "spacing"
+  }
 }
 ```
 
@@ -68,13 +68,13 @@ type: `array`
 
 ```json
 [
-	{
-		"src": "src/index.js",
-		"defer": false,
-		"async": false,
-		"type": null,
-		"position": "head"
-	}
+  {
+    "src": "src/index.js",
+    "defer": false,
+    "async": false,
+    "type": null,
+    "position": "head"
+  }
 ]
 ```
 
@@ -95,8 +95,8 @@ default:
 
 ```json
 {
-	"css": [],
-	"js": []
+  "css": [],
+  "js": []
 }
 ```
 
@@ -106,12 +106,12 @@ Assets that should always be loaded when a component uses [isolated asset loadin
 
 ```json
 {
-	"assets": {
-		"shared": {
-			"css": ["dist/tokens.css", "dist/reset.css"],
-			"js": []
-		}
-	}
+  "assets": {
+    "shared": {
+      "css": ["dist/tokens.css", "dist/reset.css"],
+      "js": []
+    }
+  }
 }
 ```
 
@@ -228,8 +228,8 @@ default:
 
 ```json
 {
-	"extension": "css",
-	"name": "index"
+  "extension": "css",
+  "name": "index"
 }
 ```
 
@@ -241,8 +241,8 @@ default:
 
 ```json
 {
-	"extension": "js",
-	"name": "index"
+  "extension": "js",
+  "name": "index"
 }
 ```
 
@@ -254,8 +254,8 @@ default:
 
 ```json
 {
-	"extension": ["json", "js"],
-	"name": "mocks"
+  "extension": ["json", "js"],
+  "name": "mocks"
 }
 ```
 
@@ -271,8 +271,8 @@ default:
 
 ```json
 {
-	"extension": "json",
-	"name": "schema"
+  "extension": "json",
+  "name": "schema"
 }
 ```
 
@@ -282,8 +282,8 @@ default:
 
 ```json
 {
-	"name": "index",
-	"extension": null
+  "name": "index",
+  "extension": null
 }
 ```
 
@@ -300,7 +300,7 @@ Example:
 
 ```json
 {
-	"@templates": "/path/to/your/templates"
+  "@templates": "/path/to/your/templates"
 }
 ```
 
@@ -310,6 +310,30 @@ You can then use `$tpl: "@templates/some-template"` or `$ref: "@templates/some-m
 
 default: `"miyagi"`<br>
 type: `string`
+
+## `lint`
+
+### `logLevel`
+
+default: `"error"`<br>
+type: `string`<br>
+values: `error|warn|info`
+
+Controls CLI lint output verbosity:
+
+- `error`: only errors
+- `warn`: errors + warnings
+- `info`: errors + warnings + info/success messages
+
+Example:
+
+```json
+{
+  "lint": {
+    "logLevel": "warn"
+  }
+}
+```
 
 ## `ui`
 
@@ -356,44 +380,44 @@ default:
 
 ```json
 {
-	"favicon": null, // path to a favicon
-	"logo": null, // path to a logo — can be used if the same logo should be used for light and dark mode
-	"light": {
-		// theming for light mode
-		"logo": null, // path to a logo
-		"navigation": {
-			"colorText": "hsl(0, 0%, 12%)",
-			"colorBackground": "hsl(0, 0%, 86%)",
-			"colorLinks": "hsl(0, 0%, 12%)",
-			"colorLinksActive": "hsl(0, 0%, 96%)",
-			"colorSearchBorder": "rgba(0, 0, 0, 0.25)"
-		},
-		"content": {
-			"colorBackground": "hsl(0, 0%, 100%)",
-			"colorText": "hsl(0, 0%, 12%)",
-			"colorHeadline1": "hsl(0, 0%, 12%)",
-			"colorHeadline2": "hsl(0, 0%, 12%)"
-		}
-	},
-	"dark": {
-		// theming for light mode
-		"logo": null, // path to a logo
-		"navigation": {
-			"colorText": "hsl(0, 0%, 100%)",
-			"colorBackground": "hsl(0, 0%, 16%)",
-			"colorLinks": "hsl(0, 0%, 100%)",
-			"colorLinksActive": "hsl(0, 0%, 16%)",
-			"colorSearchBorder": "rgba(255, 255, 255, 0.25)"
-		},
-		"content": {
-			"colorBackground": "hsl(0, 0%, 16%)",
-			"colorText": "hsl(0, 0%, 100%)",
-			"colorHeadline1": "hsl(0, 0%, 100%)",
-			"colorHeadline2": "hsl(0, 0%, 100%)"
-		}
-	},
-	"css": null, // string of CSS which gets added to miyagi and components. can be used to changed the styling of miyagi or e.g. add custom fonts,
-	"js": null // string of JS which gets added to components
+  "favicon": null, // path to a favicon
+  "logo": null, // path to a logo — can be used if the same logo should be used for light and dark mode
+  "light": {
+    // theming for light mode
+    "logo": null, // path to a logo
+    "navigation": {
+      "colorText": "hsl(0, 0%, 12%)",
+      "colorBackground": "hsl(0, 0%, 86%)",
+      "colorLinks": "hsl(0, 0%, 12%)",
+      "colorLinksActive": "hsl(0, 0%, 96%)",
+      "colorSearchBorder": "rgba(0, 0, 0, 0.25)"
+    },
+    "content": {
+      "colorBackground": "hsl(0, 0%, 100%)",
+      "colorText": "hsl(0, 0%, 12%)",
+      "colorHeadline1": "hsl(0, 0%, 12%)",
+      "colorHeadline2": "hsl(0, 0%, 12%)"
+    }
+  },
+  "dark": {
+    // theming for light mode
+    "logo": null, // path to a logo
+    "navigation": {
+      "colorText": "hsl(0, 0%, 100%)",
+      "colorBackground": "hsl(0, 0%, 16%)",
+      "colorLinks": "hsl(0, 0%, 100%)",
+      "colorLinksActive": "hsl(0, 0%, 16%)",
+      "colorSearchBorder": "rgba(255, 255, 255, 0.25)"
+    },
+    "content": {
+      "colorBackground": "hsl(0, 0%, 16%)",
+      "colorText": "hsl(0, 0%, 100%)",
+      "colorHeadline1": "hsl(0, 0%, 100%)",
+      "colorHeadline2": "hsl(0, 0%, 100%)"
+    }
+  },
+  "css": null, // string of CSS which gets added to miyagi and components. can be used to changed the styling of miyagi or e.g. add custom fonts,
+  "js": null // string of JS which gets added to components
 }
 ```
 

--- a/lib/cli/lint.js
+++ b/lib/cli/lint.js
@@ -4,6 +4,11 @@ import getConfig from "../config.js";
 import log from "../logger.js";
 import { getComponentData } from "../mocks/index.js";
 import validateMockData from "../validator/mocks.js";
+import {
+	getSchemaValidationMode,
+	toSchemaValidationResult,
+	validateSchemas,
+} from "../validator/schemas.js";
 import { t } from "../i18n/index.js";
 
 /**
@@ -14,6 +19,8 @@ export default async function lint(args) {
 
 	const componentArg = args._.slice(1)[0];
 	const config = await getConfig(args);
+	process.env.MIYAGI_LOG_CONTEXT = "lint";
+	process.env.MIYAGI_LOG_LEVEL = config.lint?.logLevel || "error";
 	global.app = await init(config);
 
 	if (componentArg) {
@@ -23,8 +30,20 @@ export default async function lint(args) {
 		);
 
 		if (component) {
+			const schemaValidation = validateSchemas({
+				components: [component],
+			});
+
+			if (schemaValidation.errors.length > 0) {
+				reportSchemaErrors(schemaValidation.errors);
+				process.exit(1);
+			}
+
+			log("success", "All schemas valid.");
+
 			await validateComponentMockData({
 				component,
+				validSchemas: schemaValidation.validSchemas,
 			});
 		} else {
 			log("error", `The component ${componentArg} does not seem to exist.`);
@@ -40,81 +59,90 @@ export default async function lint(args) {
  */
 async function validateAllMockData(exitProcess = true) {
 	log("info", t("linter.all.start"));
-
-	const promises = [];
-
-	global.state.routes.forEach((route) => {
-		if (route.type === "components") {
-			promises.push(
-				new Promise((resolve, reject) => {
-					validateComponentMockData({
-						component: route,
-						silent: true,
-						exitProcess: false,
-					})
-						.then((result) => resolve(result))
-						.catch((err) => {
-							console.error(err);
-							reject();
-						});
-				}),
-			);
-		}
+	const mode = getSchemaValidationMode();
+	const components = global.state.routes.filter(
+		(route) => route.type === "components" && route.paths.tpl,
+	);
+	const schemaValidation = validateSchemas({
+		components,
 	});
+	const invalidSchemaComponents = new Set(
+		schemaValidation.errors.map((entry) => entry.component),
+	);
 
-	Promise.all(promises)
-		.then((results) => {
-			const mockInvalidResults = results.filter(
-				(result) => result?.valid === false && result.type === "mocks",
-			);
-			const schemaInvalidResults = results.filter(
-				(result) => result?.valid === false && result.type === "schema",
-			);
+	if (schemaValidation.errors.length === 0) {
+		log("success", "All schemas valid.");
+	}
 
-			if (
-				mockInvalidResults.length === 0 &&
-				schemaInvalidResults.length === 0
-			) {
-				log("success", t("linter.all.valid"));
-				if (exitProcess) {
-					process.exit(0);
-				}
-			}
+	if (schemaValidation.errors.length > 0 && mode === "fail-fast") {
+		reportSchemaErrors(schemaValidation.errors);
+		log(
+			"error",
+			schemaValidation.errors.length === 1
+				? t("linter.all.schema.invalid.one")
+				: t("linter.all.schema.invalid.other").replace(
+						"{{amount}}",
+						schemaValidation.errors.length,
+					),
+		);
+		if (exitProcess) {
+			process.exit(1);
+		}
+		return;
+	}
 
-			if (schemaInvalidResults.length > 0) {
-				log(
-					"error",
-					schemaInvalidResults.length === 1
-						? t("linter.all.schema.invalid.one")
-						: t("linter.all.schema.invalid.other").replace(
-								"{{amount}}",
-								schemaInvalidResults.length,
-							),
-				);
-			}
+	const results = await Promise.all(
+		components
+			.filter((route) => !invalidSchemaComponents.has(route.paths.dir.short))
+			.map((component) =>
+				validateComponentMockData({
+					component,
+					silent: true,
+					exitProcess: false,
+					validSchemas: schemaValidation.validSchemas,
+				}),
+			),
+	);
+	const mockInvalidResults = results.filter(
+		(result) => result?.valid === false && result.type === "mocks",
+	);
 
-			if (mockInvalidResults.length > 0) {
-				log(
-					"error",
-					mockInvalidResults.length === 1
-						? t("linter.all.mocks.invalid.one")
-						: t("linter.all.mocks.invalid.other").replace(
-								"{{amount}}",
-								mockInvalidResults.length,
-							),
-				);
-			}
+	if (mode === "collect-all" && schemaValidation.errors.length > 0) {
+		reportSchemaErrors(schemaValidation.errors);
+		log(
+			"error",
+			schemaValidation.errors.length === 1
+				? t("linter.all.schema.invalid.one")
+				: t("linter.all.schema.invalid.other").replace(
+						"{{amount}}",
+						schemaValidation.errors.length,
+					),
+		);
+	}
 
-			if (exitProcess) {
-				process.exit(1);
-			}
-		})
-		.catch((err) => {
-			console.error(err);
-			if (exitProcess) {
-				process.exit(1);
-			}
-		});
+	if (mockInvalidResults.length > 0) {
+		log(
+			"error",
+			mockInvalidResults.length === 1
+				? t("linter.all.mocks.invalid.one")
+				: t("linter.all.mocks.invalid.other").replace(
+						"{{amount}}",
+						mockInvalidResults.length,
+					),
+		);
+	}
+
+	if (mockInvalidResults.length === 0 && schemaValidation.errors.length === 0) {
+		log("success", t("linter.all.valid"));
+		if (exitProcess) {
+			process.exit(0);
+		}
+		return;
+	}
+
+	if (exitProcess) {
+		process.exit(1);
+	}
 }
 
 /**
@@ -122,12 +150,14 @@ async function validateAllMockData(exitProcess = true) {
  * @param {object} obj.component
  * @param {boolean} [obj.silent]
  * @param {boolean} [obj.exitProcess]
+ * @param {Array<object>} [obj.validSchemas]
  * @returns {Promise<object|null>}
  */
 async function validateComponentMockData({
 	component,
 	silent,
 	exitProcess = true,
+	validSchemas = [],
 }) {
 	if (!silent) {
 		log(
@@ -139,42 +169,60 @@ async function validateComponentMockData({
 		);
 	}
 
-	const data = await getComponentData(component);
+	const data = (await getComponentData(component)) || [];
 
-	if (data) {
-		for (const { messages } of data) {
+	if (data.length > 0) {
+		for (const { messages = [] } of data) {
 			for (const { type, text, verbose } of messages) {
 				log(type, text, verbose);
 			}
 		}
-
-		const results = validateMockData(component, data);
-
-		if (!results) return null;
-
-		if (results.length === 0) {
-			if (!silent) {
-				log("success", t("linter.component.valid"));
-			}
-
-			if (exitProcess) {
-				process.exit(0);
-			} else {
-				return {
-					valid: true,
-				};
-			}
-		} else {
-			if (exitProcess) {
-				process.exit(0);
-			} else {
-				return {
-					valid: false,
-					type: results[0].type,
-				};
-			}
-		}
 	}
 
-	return null;
+	const results = validateMockData(component, data, false, validSchemas);
+
+	if (!results) return null;
+
+	if (results.length === 0) {
+		if (!silent) {
+			log("success", t("linter.component.valid"));
+		}
+
+		if (exitProcess) {
+			process.exit(0);
+		}
+
+		return {
+			valid: true,
+		};
+	}
+
+	if (exitProcess) {
+		process.exit(1);
+	}
+
+	return {
+		valid: false,
+		type: results[0].type,
+	};
+}
+
+/**
+ * @param {Array<object>} schemaErrors
+ */
+function reportSchemaErrors(schemaErrors) {
+	schemaErrors.forEach((entry) => {
+		const result = toSchemaValidationResult(entry);
+		log("error", `${entry.component}:\n${result.data[0].message}`);
+		log("error", `schema: ${entry.schemaFile}`);
+		if (entry.schemaPath || entry.instancePath) {
+			log(
+				"error",
+				`schemaPath: ${entry.schemaPath || "-"} | instancePath: ${entry.instancePath || "-"}`,
+			);
+		}
+		if (entry.hint) {
+			log("warn", entry.hint);
+		}
+	});
 }

--- a/lib/constants/lint-log-levels.js
+++ b/lib/constants/lint-log-levels.js
@@ -1,0 +1,11 @@
+export const LINT_LOG_LEVELS = Object.freeze({
+	ERROR: "error",
+	WARN: "warn",
+	INFO: "info",
+});
+
+export const LINT_LOG_LEVEL_ORDER = Object.freeze({
+	[LINT_LOG_LEVELS.ERROR]: 0,
+	[LINT_LOG_LEVELS.WARN]: 1,
+	[LINT_LOG_LEVELS.INFO]: 2,
+});

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -46,6 +46,9 @@ export default {
 			render: null,
 			options: {},
 		},
+		lint: {
+			logLevel: "error",
+		},
 		extensions: [],
 		files: {
 			css: {
@@ -96,7 +99,9 @@ export default {
 		},
 		schema: {
 			ajv: AJV,
+			verbose: false,
 		},
+		schemaValidationMode: "collect-all",
 	},
 	projectName: "miyagi",
 	defaultPort: 5000,

--- a/lib/i18n/en.js
+++ b/lib/i18n/en.js
@@ -70,6 +70,10 @@ export default {
 			invalid: "Mock data does not match schema file.",
 			noSchemaFound:
 				"No schema file found or the schema file could not be parsed as valid JSON.",
+			schemaMissing:
+				"Component {{component}} has no schema file (expected: {{schemaFile}}). Consider adding it to components.ignores if this is expected.",
+			schemaParseFailed:
+				"Schema file {{schemaFile}} could not be parsed as {{format}}.",
 		},
 	},
 	serverStarted: "Running miyagi server at http://localhost:{{port}}",

--- a/lib/init/config.js
+++ b/lib/init/config.js
@@ -7,6 +7,7 @@ import deepMerge from "deepmerge";
 import log from "../logger.js";
 import appConfig from "../default-config.js";
 import { t, available as langAvailable } from "../i18n/index.js";
+import { LINT_LOG_LEVELS } from "../constants/lint-log-levels.js";
 import fs from "fs";
 import path from "path";
 
@@ -324,6 +325,14 @@ export default (userConfig = {}) => {
 
 	if (!langAvailable.includes(merged.ui.lang)) {
 		merged.ui.lang = "en";
+	}
+
+	if (!Object.values(LINT_LOG_LEVELS).includes(merged.lint.logLevel)) {
+		log(
+			"warn",
+			`Invalid config.lint.logLevel "${merged.lint.logLevel}". Falling back to "${defaultUserConfig.lint.logLevel}".`,
+		);
+		merged.lint.logLevel = defaultUserConfig.lint.logLevel;
 	}
 
 	return merged;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,3 +1,8 @@
+import {
+	LINT_LOG_LEVEL_ORDER,
+	LINT_LOG_LEVELS,
+} from "./constants/lint-log-levels.js";
+
 const COLORS = {
 	grey: "\x1b[90m",
 	red: "\x1b[31m",
@@ -21,8 +26,17 @@ const TYPES = {
  * @param {string|Error} [verboseMessage]
  */
 export default function log(type, message, verboseMessage) {
-	if (process.env.MIYAGI_JS_API) return;
-	if (!(type in TYPES)) return;
+	if (process.env.MIYAGI_JS_API) {
+		return;
+	}
+
+	if (!(type in TYPES)) {
+		return;
+	}
+
+	if (!shouldLogType(type)) {
+		return;
+	}
 
 	const date = new Date();
 	const year = date.getFullYear();
@@ -57,6 +71,27 @@ export default function log(type, message, verboseMessage) {
 			message: verboseMessage,
 		});
 	}
+}
+
+/**
+ * @param {string} type
+ * @returns {boolean}
+ */
+function shouldLogType(type) {
+	if (process.env.MIYAGI_LOG_CONTEXT !== "lint") {
+		return true;
+	}
+
+	const configuredLevel = process.env.MIYAGI_LOG_LEVEL || "error";
+	const normalizedType = type === "success" ? "info" : type;
+	const configuredLevelValue =
+		LINT_LOG_LEVEL_ORDER[configuredLevel] ??
+		LINT_LOG_LEVEL_ORDER[LINT_LOG_LEVELS.ERROR];
+	const typeLevelValue =
+		LINT_LOG_LEVEL_ORDER[normalizedType] ??
+		LINT_LOG_LEVEL_ORDER[LINT_LOG_LEVELS.INFO];
+
+	return typeLevelValue <= configuredLevelValue;
 }
 
 /**

--- a/lib/state/file-contents.js
+++ b/lib/state/file-contents.js
@@ -12,6 +12,31 @@ import * as helpers from "../helpers.js";
 import log from "../logger.js";
 
 /**
+ * @param {string} fileName
+ * @returns {boolean}
+ */
+function isSchemaFile(fileName) {
+	const schemaFileName = `${global.config.files.schema.name}.${global.config.files.schema.extension}`;
+	return path.basename(fileName) === schemaFileName;
+}
+
+/**
+ * @param {string} fileName
+ * @param {Error & { code?: string }} err
+ */
+function markFileReadError(fileName, err) {
+	if (!global.state?.fileReadErrors || !isSchemaFile(fileName)) {
+		return;
+	}
+
+	global.state.fileReadErrors[fileName] = {
+		type: "schema-parse",
+		code: err?.code || null,
+		message: err?.message || String(err),
+	};
+}
+
+/**
  * Checks if a given array of file paths includes a given file path
  * @param {string} file - file path string
  * @param {Array} fileNames - array of file path string
@@ -134,8 +159,13 @@ export const readFile = async function (fileName) {
 		case [".yaml", ".yml"].includes(path.extname(fileName)):
 			{
 				try {
-					return await getYamlFileContent(fileName);
+					const content = await getYamlFileContent(fileName);
+					if (global.state?.fileReadErrors) {
+						delete global.state.fileReadErrors[fileName];
+					}
+					return content;
 				} catch (err) {
+					markFileReadError(fileName, err);
 					log("error", `Error when reading file ${fileName}`, err);
 				}
 			}
@@ -153,8 +183,13 @@ export const readFile = async function (fileName) {
 			[".js", ".mjs"].includes(path.extname(fileName)):
 			{
 				try {
-					return await getJsFileContent(fileName);
+					const content = await getJsFileContent(fileName);
+					if (global.state?.fileReadErrors) {
+						delete global.state.fileReadErrors[fileName];
+					}
+					return content;
 				} catch (err) {
+					markFileReadError(fileName, err);
 					log("error", `Error when reading file ${fileName}`, err);
 				}
 			}
@@ -162,8 +197,13 @@ export const readFile = async function (fileName) {
 		case fileName.endsWith(".json"):
 			{
 				try {
-					return await getParsedJsonFileContent(fileName);
+					const content = await getParsedJsonFileContent(fileName);
+					if (global.state?.fileReadErrors) {
+						delete global.state.fileReadErrors[fileName];
+					}
+					return content;
 				} catch (err) {
+					markFileReadError(fileName, err);
 					log("error", `Error when reading file ${fileName}`, err);
 				}
 			}
@@ -187,6 +227,9 @@ export const readFile = async function (fileName) {
  */
 export const getFileContents = async function (sourceTree) {
 	const fileContents = {};
+	if (global.state) {
+		global.state.fileReadErrors = {};
+	}
 	const paths = await getFilePaths(sourceTree);
 
 	if (paths) {

--- a/lib/state/index.js
+++ b/lib/state/index.js
@@ -18,6 +18,7 @@ export default async function setState(methods) {
 	if (!global.state) {
 		global.state = {
 			routes: [],
+			fileReadErrors: {},
 		};
 	}
 

--- a/lib/validator/mocks.js
+++ b/lib/validator/mocks.js
@@ -1,4 +1,5 @@
 import jsYaml from "js-yaml";
+import { existsSync } from "node:fs";
 import deepMerge from "deepmerge";
 import log from "../logger.js";
 import { t } from "../i18n/index.js";
@@ -9,31 +10,19 @@ import { t } from "../i18n/index.js";
  * @param {object} component
  * @param {Array} dataArray - an array with mock data
  * @param {boolean} [noCli]
+ * @param {Array<object>} [validSchemas]
  * @returns {null|object[]} null if there is no schema or an array with booleans defining the validity of the entries in the data array
  */
-export default function validateMockData(component, dataArray, noCli) {
+export default function validateMockData(
+	component,
+	dataArray,
+	noCli,
+	validSchemas = [],
+) {
 	const componentSchema =
 		global.state.fileContents[component.paths.schema.full];
 
 	if (componentSchema) {
-		const schemas = [];
-
-		Object.entries(global.state.fileContents).forEach(([key, value]) => {
-			if (
-				key.endsWith(
-					`${global.config.files.schema.name}.${global.config.files.schema.extension}`,
-				)
-			) {
-				const arr = Array.isArray(value) ? value : [value];
-
-				arr.forEach((schema) => {
-					if (schema && componentSchema.$id !== schema.$id) {
-						schemas.push(schema);
-					}
-				});
-			}
-		});
-
 		const validity = [];
 		let validate;
 		let jsonSchemaValidator;
@@ -43,16 +32,19 @@ export default function validateMockData(component, dataArray, noCli) {
 				deepMerge(
 					{
 						allErrors: true,
-						schemas: schemas.map((schema, i) => {
-							if (!schema.$id) {
-								schema.$id = i.toString();
-							}
-							return schema;
-						}),
 					},
 					global.config.schema.options || {},
 				),
 			);
+
+			validSchemas.forEach((entry) => {
+				// Preload only other validated schemas for cross-component $ref resolution.
+				// The current component schema is compiled below and must not be added twice.
+				if (entry?.schemaFile !== component.paths.schema.full && entry?.schema) {
+					jsonSchemaValidator.addSchema(entry.schema);
+				}
+			});
+
 			validate = jsonSchemaValidator.compile(componentSchema);
 		} catch (e) {
 			const message = e.toString();
@@ -95,9 +87,22 @@ export default function validateMockData(component, dataArray, noCli) {
 	}
 
 	if (!global.config.isBuild && !noCli) {
+		const parseError = global.state.fileReadErrors?.[component.paths.schema.full];
+		const schemaExistsOnDisk = existsSync(component.paths.schema.full);
+		const warningMessage = parseError
+			? t("validator.mocks.schemaParseFailed")
+					.replace("{{schemaFile}}", component.paths.schema.short)
+					.replace("{{format}}", "JSON or YAML")
+			: schemaExistsOnDisk
+				? t("validator.mocks.schemaParseFailed")
+						.replace("{{schemaFile}}", component.paths.schema.short)
+						.replace("{{format}}", "JSON or YAML")
+				: t("validator.mocks.schemaMissing")
+						.replace("{{component}}", component.paths.dir.short)
+						.replace("{{schemaFile}}", component.paths.schema.short);
 		log(
 			"warn",
-			`${component.paths.dir.short}: ${t("validator.mocks.noSchemaFound")}`,
+			warningMessage,
 		);
 	}
 

--- a/lib/validator/schemas.js
+++ b/lib/validator/schemas.js
@@ -1,0 +1,234 @@
+// @ts-check
+
+import deepMerge from "deepmerge";
+
+const DEFAULT_SCHEMA_VALIDATION_MODE = "collect-all";
+const ALLOWED_SCHEMA_VALIDATION_MODES = new Set(["collect-all", "fail-fast"]);
+
+/**
+ * @returns {"collect-all"|"fail-fast"}
+ */
+export function getSchemaValidationMode() {
+	const mode = global.config.schemaValidationMode ?? DEFAULT_SCHEMA_VALIDATION_MODE;
+
+	if (!ALLOWED_SCHEMA_VALIDATION_MODES.has(mode)) {
+		return DEFAULT_SCHEMA_VALIDATION_MODE;
+	}
+
+	return mode;
+}
+
+/**
+ * @param {object} options
+ * @param {Array<object>} [options.components]
+ * @returns {{ valid: boolean, errors: Array<object>, validSchemas: Array<object> }}
+ */
+export function validateSchemas({ components } = {}) {
+	const validSchemas = [];
+	const errors = [];
+	const componentRoutes =
+		components ??
+		global.state.routes.filter((route) => route.type === "components" && route.paths.tpl);
+	const validator = new global.config.schema.ajv(
+		deepMerge(
+			{
+				allErrors: true,
+			},
+			global.config.schema.options || {},
+		),
+	);
+
+	let pendingSchemas = componentRoutes
+		.map((component, index) => {
+			// Absolute schema file path.
+			const schemaFile = component.paths.schema.full;
+			// Parsed schema from in-memory state cache.
+			const schemaFromState = global.state.fileContents[schemaFile];
+
+			if (!schemaFromState) {
+				return null;
+			}
+
+			const schema = structuredClone(schemaFromState);
+			if (!schema.$id) {
+				schema.$id = component.paths.schema.short || schemaFile || index.toString();
+			}
+
+			return {
+				component: component.paths.dir.short,
+				schemaFile,
+				rawSchema: schemaFromState,
+				schema,
+			};
+		})
+		.filter(Boolean);
+
+	while (pendingSchemas.length > 0) {
+		let progress = false;
+		const retrySchemas = [];
+
+		pendingSchemas.forEach((entry) => {
+			try {
+				validator.compile(entry.schema);
+				if (!validator.getSchema(entry.schema.$id)) {
+					validator.addSchema(entry.schema);
+				}
+				validSchemas.push({
+					component: entry.component,
+					schemaFile: entry.schemaFile,
+					schema: entry.schema,
+				});
+				progress = true;
+			} catch (error) {
+				if (isUnresolvedRefError(error)) {
+					retrySchemas.push(entry);
+					return;
+				}
+
+				errors.push(
+					buildSchemaValidationError({
+						error,
+						component: entry.component,
+						schemaFile: entry.schemaFile,
+						rawSchema: entry.rawSchema,
+					}),
+				);
+			}
+		});
+
+		if (!progress) {
+			retrySchemas.forEach((entry) => {
+				const error = new Error(
+					`can't resolve reference while validating schema ${entry.schemaFile}`,
+				);
+				errors.push(
+					buildSchemaValidationError({
+						error,
+						component: entry.component,
+						schemaFile: entry.schemaFile,
+						rawSchema: entry.rawSchema,
+					}),
+				);
+			});
+			break;
+		}
+
+		pendingSchemas = retrySchemas;
+	}
+
+	return {
+		valid: errors.length === 0,
+		errors,
+		validSchemas,
+	};
+}
+
+/**
+ * @param {object} obj
+ * @param {Error & { errors?: Array<object> }} obj.error
+ * @param {string} obj.component
+ * @param {string} obj.schemaFile
+ * @param {object} obj.rawSchema
+ * @returns {object}
+ */
+function buildSchemaValidationError({ error, component, schemaFile, rawSchema }) {
+	const ajvErrors = Array.isArray(error?.errors) ? error.errors : [];
+	const [firstAjvError] = ajvErrors;
+	const hint = getSchemaHint(rawSchema, ajvErrors);
+	const type = isUnresolvedRefError(error) ? "schema-ref" : "schema";
+
+	return {
+		type,
+		component,
+		schemaFile,
+		message: error?.toString?.() || "Unknown schema validation error",
+		schemaPath: firstAjvError?.schemaPath || "",
+		instancePath: firstAjvError?.instancePath || "",
+		hint,
+		details: ajvErrors.map((entry) => ({
+			keyword: entry.keyword,
+			message: entry.message,
+			schemaPath: entry.schemaPath,
+			instancePath: entry.instancePath,
+			params: entry.params,
+		})),
+	};
+}
+
+/**
+ * @param {object} schema
+ * @param {Array<object>} ajvErrors
+ * @returns {string|undefined}
+ */
+function getSchemaHint(schema, ajvErrors) {
+	if (schema?.properties === null) {
+		return "Hint: `properties` resolves to null. In YAML this often means `properties:` has no nested keys.";
+	}
+
+	if (
+		ajvErrors.some(
+			(error) =>
+				error?.schemaPath?.endsWith("/properties/type") &&
+				error?.instancePath?.includes("/properties/"),
+		)
+	) {
+		return "Hint: check each field `type` value; it must be a valid JSON Schema type.";
+	}
+
+	return undefined;
+}
+
+/**
+ * @param {Error & { message?: string, missingRef?: string, missingSchema?: string, code?: string }} error
+ * @returns {boolean}
+ */
+function isUnresolvedRefError(error) {
+	if (typeof error?.missingRef === "string" && error.missingRef.length > 0) {
+		return true;
+	}
+
+	if (
+		typeof error?.missingSchema === "string" &&
+		error.missingSchema.length > 0
+	) {
+		return true;
+	}
+
+	if (error?.code === "ERR_MISSING_REF") {
+		return true;
+	}
+
+	return /can't resolve reference|missing ref|missing schema/i.test(
+		error?.message || "",
+	);
+}
+
+/**
+ * @param {object} schemaError
+ * @param {object} [options]
+ * @param {boolean} [options.verbose]
+ * @returns {{ type: "schema"|"schema-ref", data: Array<object> }}
+ */
+export function toSchemaValidationResult(schemaError, options = {}) {
+	const useVerbose =
+		options.verbose ?? global.config?.schema?.verbose === true;
+	const formattedError = {
+		message: schemaError.message,
+		component: schemaError.component,
+		schemaFile: schemaError.schemaFile,
+		hint: schemaError.hint,
+	};
+
+	if (useVerbose) {
+		formattedError.schemaPath = schemaError.schemaPath;
+		formattedError.instancePath = schemaError.instancePath;
+		formattedError.details = schemaError.details;
+	}
+
+	return {
+		type: schemaError.type || "schema",
+		data: [
+			formattedError,
+		],
+	};
+}

--- a/tests/_setup/components/invalid-properties-null/schema.json
+++ b/tests/_setup/components/invalid-properties-null/schema.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://fixture.local/invalid-properties-null",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": null
+}

--- a/tests/_setup/components/ref-consumer/ref-consumer.twig
+++ b/tests/_setup/components/ref-consumer/ref-consumer.twig
@@ -1,0 +1,1 @@
+<div>{{ value }}</div>

--- a/tests/_setup/components/ref-consumer/schema.json
+++ b/tests/_setup/components/ref-consumer/schema.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://fixture.local/ref-consumer",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"value": {
+			"$ref": "https://fixture.local/ref-source#/properties/value"
+		}
+	}
+}

--- a/tests/_setup/components/ref-missing/ref-missing.twig
+++ b/tests/_setup/components/ref-missing/ref-missing.twig
@@ -1,0 +1,1 @@
+<div>{{ value }}</div>

--- a/tests/_setup/components/ref-missing/schema.json
+++ b/tests/_setup/components/ref-missing/schema.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://fixture.local/ref-missing",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"value": {
+			"$ref": "https://fixture.local/does-not-exist#/properties/value"
+		}
+	}
+}

--- a/tests/_setup/components/ref-source/ref-source.twig
+++ b/tests/_setup/components/ref-source/ref-source.twig
@@ -1,0 +1,1 @@
+<div>{{ value }}</div>

--- a/tests/_setup/components/ref-source/schema.json
+++ b/tests/_setup/components/ref-source/schema.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://fixture.local/ref-source",
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"value": {
+			"type": "string"
+		}
+	}
+}

--- a/tests/api/index.test.js
+++ b/tests/api/index.test.js
@@ -70,10 +70,23 @@ const RESPONSES = {
 			type: "schema",
 		},
 	],
+	refMissing: [
+		{
+			type: "schema-ref",
+			data: [
+				{
+					message: expect.stringContaining("can't resolve reference"),
+				},
+			],
+		},
+	],
 };
 
 beforeAll(() => (process.env.MIYAGI_JS_API = true));
 afterAll(() => (process.env.MIYAGI_JS_API = false));
+afterEach(
+	() => (defaultConfig.defaultUserConfig.schemaValidationMode = "collect-all"),
+);
 
 describe("getMockData", () => {
 	describe("without passing a component name", () => {
@@ -196,7 +209,7 @@ describe("createBuild", () => {
 
 		expect(await createBuild()).toStrictEqual({
 			success: true,
-			message: "Build done! Wrote 94 directories and files.",
+			message: "Build done! Wrote 112 directories and files.",
 		});
 
 		[
@@ -481,27 +494,73 @@ describe("createComponent", () => {
 });
 
 describe("lintComponents", () => {
-	test("validates the mock data of all components against their schema files and returns an array with all errors", async () => {
-		expect(await lintComponents()).toStrictEqual({
-			success: false,
-			data: [
-				// Mocks that do not match the schema
-				{
-					component: "card",
-					errors: RESPONSES.card,
-				},
-				// Invalid schema file, mock file exists
-				{
-					component: "icon",
-					errors: RESPONSES.icon,
-				},
-				// Invalid schema file, no mock file exists
-				{
-					component: "image",
-					errors: RESPONSES.image,
-				},
-			],
+	test("in collect-all mode, returns schema and mock errors after full pipeline", async () => {
+		defaultConfig.defaultUserConfig.schemaValidationMode = "collect-all";
+
+		const result = await lintComponents();
+		expect(result.success).toBe(false);
+		expect(result.data.map((entry) => entry.component)).toStrictEqual([
+			"card",
+			"icon",
+			"image",
+			"ref-missing",
+		]);
+
+		expect(result.data.find((entry) => entry.component === "card")).toStrictEqual({
+			component: "card",
+			errors: RESPONSES.card,
 		});
+
+		const iconError = result.data.find(
+			(entry) => entry.component === "icon",
+		)?.errors?.[0];
+		expect(iconError?.type).toBe("schema");
+		expect(iconError?.data?.[0]).toEqual(
+			expect.objectContaining({
+				message: RESPONSES.icon[0].data[0].message,
+				component: "icon",
+				schemaFile: expect.any(String),
+			}),
+		);
+
+		const imageError = result.data.find(
+			(entry) => entry.component === "image",
+		)?.errors?.[0];
+		expect(imageError?.type).toBe("schema");
+		expect(imageError?.data?.[0]).toEqual(
+			expect.objectContaining({
+				message: RESPONSES.image[0].data[0].message,
+				component: "image",
+				schemaFile: expect.any(String),
+			}),
+		);
+
+		const refMissingError = result.data.find(
+			(entry) => entry.component === "ref-missing",
+		)?.errors?.[0];
+		expect(refMissingError?.type).toBe("schema-ref");
+		expect(refMissingError?.data?.[0]).toEqual(
+			expect.objectContaining({
+				message: RESPONSES.refMissing[0].data[0].message,
+				component: "ref-missing",
+				schemaFile: expect.any(String),
+			}),
+		);
+	});
+
+	test("in fail-fast mode, returns schema errors and skips mock validation phase", async () => {
+		defaultConfig.defaultUserConfig.schemaValidationMode = "fail-fast";
+
+		const result = await lintComponents();
+		expect(result.success).toBe(false);
+		expect(result.data.map((entry) => entry.component)).toStrictEqual([
+			"icon",
+			"image",
+			"ref-missing",
+		]);
+		expect(
+			result.data.some((entry) => entry.component === "card"),
+		).toStrictEqual(false);
 	});
 });
 
@@ -544,19 +603,58 @@ describe("lintComponent", () => {
 
 	describe("with invalid schema file while mock file exists", () => {
 		test("returns success:false and an array with all errors", async () => {
-			expect(await lintComponent({ component: "icon" })).toStrictEqual({
-				success: false,
-				data: RESPONSES.icon,
-			});
+			const result = await lintComponent({ component: "icon" });
+			expect(result.success).toBe(false);
+			expect(result.data?.[0]).toEqual(
+				expect.objectContaining({
+					type: "schema",
+				}),
+			);
+			expect(result.data?.[0]?.data?.[0]).toEqual(
+				expect.objectContaining({
+					message: RESPONSES.icon[0].data[0].message,
+					component: "icon",
+					schemaFile: expect.any(String),
+				}),
+			);
 		});
 	});
 
 	describe("with invalid schema file while no mock file exists", () => {
 		test("returns success:false and an array with all errors", async () => {
-			expect(await lintComponent({ component: "image" })).toStrictEqual({
-				success: false,
-				data: RESPONSES.image,
-			});
+			const result = await lintComponent({ component: "image" });
+			expect(result.success).toBe(false);
+			expect(result.data?.[0]).toEqual(
+				expect.objectContaining({
+					type: "schema",
+				}),
+			);
+			expect(result.data?.[0]?.data?.[0]).toEqual(
+				expect.objectContaining({
+					message: RESPONSES.image[0].data[0].message,
+					component: "image",
+					schemaFile: expect.any(String),
+				}),
+			);
+		});
+	});
+
+	describe("with unresolved schema reference", () => {
+		test("returns success:false and schema-ref error", async () => {
+			const result = await lintComponent({ component: "ref-missing" });
+			expect(result.success).toBe(false);
+			expect(result.data?.[0]).toEqual(
+				expect.objectContaining({
+					type: "schema-ref",
+				}),
+			);
+			expect(result.data?.[0]?.data?.[0]).toEqual(
+				expect.objectContaining({
+					message: expect.stringContaining("can't resolve reference"),
+					component: "ref-missing",
+					schemaFile: expect.any(String),
+				}),
+			);
 		});
 	});
 });

--- a/tests/lib/validator/mocks.test.js
+++ b/tests/lib/validator/mocks.test.js
@@ -1,11 +1,25 @@
-import { describe, test, expect, beforeAll, afterAll } from "vitest";
-import path from "node:path";
+import {
+	describe,
+	test,
+	expect,
+	beforeAll,
+	afterAll,
+	beforeEach,
+	afterEach,
+	vi,
+} from "vitest";
 import { getComponentData } from "../../../lib/mocks/index.js";
 import validateMockData from "../../../lib/validator/mocks.js";
 import init from "../../../lib/index.js";
 
 beforeAll(() => (process.env.MIYAGI_JS_API = true));
 afterAll(() => (process.env.MIYAGI_JS_API = false));
+beforeEach(() => {
+	vi.spyOn(console, "warn").mockImplementation(() => { });
+});
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 describe("validateMockData", () => {
 	describe("with missing schema", () => {
@@ -15,6 +29,30 @@ describe("validateMockData", () => {
 			expect(
 				await validateMockData(component, await getComponentData(component)),
 			).toStrictEqual(null);
+		});
+
+		test("logs explicit missing schema warning", async () => {
+			process.env.MIYAGI_JS_API = "";
+			const component = await getComponentsObject("anchor");
+			await validateMockData(component, await getComponentData(component), false);
+
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining("has no schema file"),
+			);
+			process.env.MIYAGI_JS_API = "true";
+		});
+	});
+
+	describe("with unparseable schema", () => {
+		test("logs explicit parse-failed schema warning", async () => {
+			process.env.MIYAGI_JS_API = "";
+			const component = await getComponentsObject("video");
+			await validateMockData(component, await getComponentData(component), false);
+
+			expect(console.warn).toHaveBeenCalledWith(
+				expect.stringContaining("could not be parsed as JSON or YAML"),
+			);
+			process.env.MIYAGI_JS_API = "true";
 		});
 	});
 

--- a/tests/lib/validator/schemas.test.js
+++ b/tests/lib/validator/schemas.test.js
@@ -1,0 +1,123 @@
+// @ts-check
+
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import init from "../../../lib/index.js";
+import {
+	getSchemaValidationMode,
+	toSchemaValidationResult,
+	validateSchemas,
+} from "../../../lib/validator/schemas.js";
+
+beforeAll(() => (process.env.MIYAGI_JS_API = "true"));
+afterAll(() => (process.env.MIYAGI_JS_API = "false"));
+
+describe("validateSchemas", () => {
+	test("returns all invalid schemas while still collecting valid schemas", async () => {
+		global.app = await init("api");
+
+		const result = validateSchemas();
+
+		expect(result.valid).toBe(false);
+		expect(result.errors.map((entry) => entry.component)).toStrictEqual([
+			"icon",
+			"image",
+			"ref-missing",
+		]);
+		expect(result.validSchemas.some((entry) => entry.component === "button")).toBe(
+			true,
+		);
+		expect(
+			result.validSchemas.some((entry) => entry.component === "ref-consumer"),
+		).toBe(true);
+		expect(result.errors[0]).toEqual(
+			expect.objectContaining({
+				component: expect.any(String),
+				schemaFile: expect.any(String),
+				type: expect.any(String),
+				message: expect.any(String),
+			}),
+		);
+	});
+
+	test("classifies unresolved refs as schema-ref", async () => {
+		global.app = await init("api");
+
+		const result = validateSchemas();
+		const unresolvedRefError = result.errors.find(
+			(entry) => entry.component === "ref-missing",
+		);
+
+		expect(unresolvedRefError).toEqual(
+			expect.objectContaining({
+				type: "schema-ref",
+			}),
+		);
+	});
+});
+
+describe("getSchemaValidationMode", () => {
+	test("returns collect-all when mode is invalid", async () => {
+		global.app = await init("api");
+		global.config.schemaValidationMode = "invalid-mode";
+
+		expect(getSchemaValidationMode()).toBe("collect-all");
+	});
+});
+
+describe("toSchemaValidationResult", () => {
+	test("maps schema errors to concise linter result shape by default", () => {
+		expect(
+			toSchemaValidationResult({
+				type: "schema",
+				component: "button",
+				schemaFile: "schema.json",
+				message: "Error: schema is invalid",
+				schemaPath: "#/properties/type",
+				instancePath: "/properties/label",
+				hint: "Hint",
+				details: [],
+			}),
+		).toStrictEqual({
+			type: "schema",
+			data: [
+				{
+					message: "Error: schema is invalid",
+					component: "button",
+					schemaFile: "schema.json",
+					hint: "Hint",
+				},
+			],
+		});
+	});
+
+	test("maps schema errors to verbose linter result shape when enabled", () => {
+		expect(
+			toSchemaValidationResult(
+				{
+					type: "schema-ref",
+					component: "button",
+					schemaFile: "schema.json",
+					message: "Error: schema is invalid",
+					schemaPath: "#/properties/type",
+					instancePath: "/properties/label",
+					hint: "Hint",
+					details: [],
+				},
+				{ verbose: true },
+			),
+		).toStrictEqual({
+			type: "schema-ref",
+			data: [
+				{
+					message: "Error: schema is invalid",
+					component: "button",
+					schemaFile: "schema.json",
+					schemaPath: "#/properties/type",
+					instancePath: "/properties/label",
+					hint: "Hint",
+					details: [],
+				},
+			],
+		});
+	});
+});

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -16,6 +16,8 @@ const date = new Date(2024, 0, 1, 12, 30);
 beforeEach(() => {
 	vi.useFakeTimers();
 	vi.setSystemTime(date);
+	process.env.MIYAGI_LOG_CONTEXT = "";
+	process.env.MIYAGI_LOG_LEVEL = "";
 
 	vi.spyOn(console, "error").mockImplementation(() => {});
 	vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -26,6 +28,8 @@ beforeEach(() => {
 afterEach(() => {
 	vi.useRealTimers();
 	vi.restoreAllMocks();
+	delete process.env.MIYAGI_LOG_CONTEXT;
+	delete process.env.MIYAGI_LOG_LEVEL;
 });
 
 describe("non-verbose mode", () => {
@@ -217,5 +221,37 @@ describe("verbose mode", () => {
 				);
 			});
 		});
+	});
+});
+
+describe("lint log level filtering", () => {
+	test("error level suppresses warn/info/success", () => {
+		process.env.MIYAGI_LOG_CONTEXT = "lint";
+		process.env.MIYAGI_LOG_LEVEL = "error";
+
+		log("warn", "warning message");
+		log("info", "info message");
+		log("success", "success message");
+		log("error", "error message");
+
+		expect(console.warn).toHaveBeenCalledTimes(0);
+		expect(console.info).toHaveBeenCalledTimes(0);
+		expect(console.log).toHaveBeenCalledTimes(0);
+		expect(console.error).toHaveBeenCalledTimes(1);
+	});
+
+	test("warn level shows warn and error", () => {
+		process.env.MIYAGI_LOG_CONTEXT = "lint";
+		process.env.MIYAGI_LOG_LEVEL = "warn";
+
+		log("warn", "warning message");
+		log("info", "info message");
+		log("success", "success message");
+		log("error", "error message");
+
+		expect(console.warn).toHaveBeenCalledTimes(1);
+		expect(console.info).toHaveBeenCalledTimes(0);
+		expect(console.log).toHaveBeenCalledTimes(0);
+		expect(console.error).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary

This PR resolves schema-validation poisoning and improves lint signal/noise.

It separates schema-phase concerns from mock validation flow, preserves cross-component `$ref` resolution, and introduces configurable lint output levels for better CI/local DX.

Fixes behavior discussed in [Issue #458](https://github.com/miyagi-dev/miyagi/issues/458).

## What changed

- Added dedicated schema-phase validation module.
- Fixed schema-phase `$ref` handling using shared AJV context + retry pass.
- Added schema error classification:
  - `schema` (schema/meta invalid)
  - `schema-ref` (unresolved `$ref`)
- Added concise-by-default schema error payload; verbose payload still available.
- Added `schemaValidationMode` behavior support already wired in lint/api flows.
- Added `lint.logLevel` config (`error|warn|info`, default `error`).
- Added logger filtering for lint context based on configured level.
- Improved missing-schema warning clarity:
  - distinguishes missing schema vs parse-failed schema
  - includes expected schema path
  - guidance to use `components.ignores` when expected
- Reduced misleading parent/container warnings by linting only component routes with templates.
- Added shared lint log level constants module to avoid duplication.
- Updated docs for lint behavior + new config options.

## Fixtures and tests

Added fixtures for schema-phase edge cases:

- valid cross-component `$ref`
- unresolved `$ref`
- invalid schema shape (`properties: null`)

Expanded/updated tests for:

- schema-phase ref resolution correctness
- `schema-ref` classification
- concise vs verbose schema result mapping
- lint log-level filtering
- missing vs parse-failed schema warnings
- API lint response expectations

## Validation run

- Focused:
  - `npx vitest run tests/lib/validator/*.test.js tests/logger.test.js tests/api/index.test.js`
- Full:
  - `pnpm test`
  - `pnpm lint`

All passing.

## User-facing impact

- Lint output is more actionable, less noisy by default.
- Schema failures now report root cause/component more clearly.
- Projects with expected schema-less components can combine:
  - `components.ignores`
  - `lint.logLevel`
for clean, intentional lint output.