### PR TITLE
fix: reduce watch startup noise and log spam

### DIFF
--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -590,7 +590,7 @@ default:
 {
   "enabled": true,
   "onStart": true,
-  "format": "pretty",
+  "format": "summary",
   "destination": "stdout",
   "useColors": true
 }
@@ -602,6 +602,8 @@ Startup watch report options.
 - `destination`: currently only `stdout`
 
 Use `json` when the watch report needs to be parsed by scripts or tooling (for example CI checks or custom integrations).
+`summary` is the default to keep startup output concise on larger projects.
+`pretty` keeps richer sections, and full resolved source listing is shown only when `watch.debug.logResolvedSources=true`.
 
 CLI overrides are available:
 
@@ -624,6 +626,8 @@ default:
 ```
 
 Enable verbose watcher diagnostics while debugging reload decisions.
+
+Note: `watch.debug.logResolvedSources=true` enables full resolved watch source listing in startup report output.
 
 ## `schema`
 

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -142,7 +142,7 @@ export default {
 			report: {
 				enabled: true,
 				onStart: true,
-				format: "pretty",
+				format: "summary",
 				destination: "stdout",
 				useColors: true,
 			},

--- a/lib/init/watcher.js
+++ b/lib/init/watcher.js
@@ -161,18 +161,21 @@ function printWatchReport(report, watchConfig) {
 		`  ${colorize("grey", "Diagnostics:", useColors)} sources=${report.meta.sourceCount
 		}, ignores=${report.meta.ignoreCount}`,
 	);
-	console.info(`  ${colorize("grey", "Resolved sources:", useColors)}`);
 
-	for (const source of report.sources) {
-		const stateLabel = source.exists ? "exists" : "missing";
-		const stateColor = source.exists ? "green" : "yellow";
-		console.info(
-			`    - ${source.id} (${source.type}) ${source.resolvedPath} [${colorize(
-				stateColor,
-				stateLabel,
-				useColors,
-			)}]`,
-		);
+	if (watchConfig?.debug?.logResolvedSources) {
+		console.info(`  ${colorize("grey", "Resolved sources:", useColors)}`);
+
+		for (const source of report.sources) {
+			const stateLabel = source.exists ? "exists" : "missing";
+			const stateColor = source.exists ? "green" : "yellow";
+			console.info(
+				`    - ${source.id} (${source.type}) ${source.resolvedPath} [${colorize(
+					stateColor,
+					stateLabel,
+					useColors,
+				)}]`,
+			);
+		}
 	}
 
 	console.info(`  ${colorize("grey", "Ignored patterns:", useColors)}`);
@@ -628,6 +631,7 @@ export default function Watcher(server) {
 
 		isProcessing = true;
 		try {
+			log("info", t("updatingStarted"));
 			const events = snapshotPendingEvents(pendingByPath);
 			pendingByPath.clear();
 			await handleFileChange(events);
@@ -713,7 +717,6 @@ export default function Watcher(server) {
 				log("info", `watch:event=${eventType} path=${changedPath}`);
 			}
 
-			log("info", t("updatingStarted"));
 			enqueueEvent(eventType, changedPath);
 		});
 

--- a/tests/lib/init/config.test.js
+++ b/tests/lib/init/config.test.js
@@ -11,6 +11,11 @@ describe("config processing", () => {
 			expect(config.watch.backend).toBe("chokidar");
 		});
 
+		test("defaults watch report format to summary", () => {
+			const config = getConfig({});
+			expect(config.watch.report.format).toBe("summary");
+		});
+
 		test("derives sources from components folder by default", () => {
 			const config = getConfig({
 				components: { folder: "src" },

--- a/tests/lib/init/watcher.test.js
+++ b/tests/lib/init/watcher.test.js
@@ -31,6 +31,10 @@ vi.mock("../../../lib/state/file-contents.js", () => ({
 	readFile: vi.fn(async () => ({})),
 }));
 
+vi.mock("../../../lib/logger.js", () => ({
+	default: vi.fn(),
+}));
+
 vi.mock("ws", () => ({
 	WebSocketServer: vi.fn(function MockWebSocketServer() {
 		this.on = vi.fn((eventName, callback) => {
@@ -55,6 +59,7 @@ vi.mock("ws", () => ({
 }));
 
 const { default: Watcher } = await import("../../../lib/init/watcher.js");
+const { default: mockLogger } = await import("../../../lib/logger.js");
 
 describe("Watcher", () => {
 	let mockServer;
@@ -157,12 +162,41 @@ describe("Watcher", () => {
 		await vi.advanceTimersByTimeAsync(150);
 
 		expect(mockSetState).toHaveBeenCalledTimes(1);
+		const updatingStartedCalls = mockLogger.mock.calls.filter(
+			([type, message]) =>
+				type === "info" &&
+				typeof message === "string" &&
+				message.includes("miyagi is updating the state"),
+		);
+		expect(updatingStartedCalls).toHaveLength(1);
 		expect(mockSetState).toHaveBeenCalledWith({
 			sourceTree: true,
 			fileContents: true,
 			menu: true,
 			partials: true,
 		});
+	});
+
+	test("prints resolved source list only when debug.logResolvedSources is enabled", () => {
+		global.config.watch.report.format = "pretty";
+		global.config.watch.debug.logResolvedSources = false;
+		Watcher(mockServer);
+
+		expect(
+			consoleInfoSpy.mock.calls.some(([line]) =>
+				String(line).includes("Resolved sources:"),
+			),
+		).toBe(false);
+
+		consoleInfoSpy.mockClear();
+		global.config.watch.debug.logResolvedSources = true;
+		Watcher(mockServer);
+
+		expect(
+			consoleInfoSpy.mock.calls.some(([line]) =>
+				String(line).includes("Resolved sources:"),
+			),
+		).toBe(true);
 	});
 
 	test("sends structured reload payload to websocket clients", async () => {


### PR DESCRIPTION
## Summary
- default watch report format to `summary` to reduce startup verbosity in large projects
- print full resolved source list only when `watch.debug.logResolvedSources=true`
- log `updatingStarted` once per coalesced batch (instead of once per file event)
- update docs and tests for new default/report/log behavior

## Test plan
- [x] `pnpm lint`
- [x] `npx vitest run tests/lib/init/watcher.test.js tests/lib/init/config.test.js`

Made with [Cursor](https://cursor.com)