### PR TITLE
feat: cli dx improvements and adds a doctor cli

### DIFF
--- a/.cursor/commands/commit.md
+++ b/.cursor/commands/commit.md
@@ -1,0 +1,56 @@
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+description: Ready a new commit for review
+---
+
+# Ready a new commit for review
+
+Current git status: !'git status'
+
+Recent commits: !'git log --oneline -5'
+
+- Create a commit based on the staged changes.
+- Commits must follow converntional commits
+
+## Merge Request Descriptions
+
+**Format merge request descriptions to be clear, approachable, and collaborative.**
+
+### Structure
+
+1. **Summary** - Brief description of what changed and why
+2. **What changed** - Technical breakdown organized by category (architecture, files, tests)
+3. **Testing** - Commands to verify the changes
+
+### Language Style
+
+- **Collaborative, not prescriptive** - "This enables..." not "You must..."
+- **Clear and approachable** - Avoid jargon; explain technical decisions
+- **Concise without being terse** - Enough detail to understand, not exhaustive
+- **Highlight critical contracts** - When values/types must match across systems, make it prominent
+- **Use tables for enumerated values** - Makes scanning easier than prose
+
+### Example Structure
+
+```markdown
+## Summary
+
+Brief description of the change and its purpose.
+
+## What changed
+
+**Category 1:**
+
+- Bullet points of changes
+
+**Category 2:**
+
+- More changes
+
+## Testing
+
+- `yarn test:unit` - Unit tests
+- `yarn playwright test <path>` - E2E tests
+```
+
+**Why this matters:** Good PR descriptions reduce review friction, serve as documentation, and help future developers understand decisions.

--- a/.cursor/commands/council.md
+++ b/.cursor/commands/council.md
@@ -1,0 +1,9 @@
+# council
+
+Based on the given area of interest, please:
+
+1. Dig around the codebase in terms of that given area of interest, gather general information such as keywords and architecture overview.
+2. Spawn off n=5 (unless specified otherwise) task agents to dig deeper into the codebase in terms of that given area of interest, some of them should be out of the box for variance.
+3. Once the task agents are done, use the information to do what the user wants.
+
+If user is in plan mode, use the information to create the plan.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,52 @@ _miyagi_ is a component development tool for JavaScript templating engines.
 
 ## Requirements
 
-- NodeJS `20.11.0` or higher
+- NodeJS `24` or higher
+
+## Quick start
+
+Twig example:
+
+```bash
+pnpm add -D @schalkneethling/miyagi-core twing
+```
+
+Create `.miyagi.mjs`:
+
+```js
+import { createSynchronousEnvironment, createSynchronousFilesystemLoader } from "twing";
+import fs from "node:fs";
+
+const twing = createSynchronousEnvironment(createSynchronousFilesystemLoader(fs));
+
+export default {
+  components: {
+    folder: "src/components",
+  },
+  docs: {
+    folder: "docs",
+  },
+  engine: {
+    async render({ name, context, cb }) {
+      try {
+        return cb(null, await twing.render(name, context));
+      } catch (err) {
+        return cb(err.toString());
+      }
+    },
+  },
+};
+```
+
+Then start miyagi:
+
+```bash
+pnpm exec miyagi start
+```
+
+Open `http://localhost:5000`.
+
+If you use a different template engine, swap the `engine.render` implementation for that engine.
 
 ## Demos
 
@@ -37,6 +82,8 @@ _miyagi_ is a component development tool for JavaScript templating engines.
 ## Documentation
 
 [https://docs.miyagi.dev](https://docs.miyagi.dev)
+
+CLI quickstart: [https://docs.miyagi.dev/cli-commands/starting-miyagi/](https://docs.miyagi.dev/cli-commands/starting-miyagi/)
 
 ## Sponsor
 

--- a/bin/miyagi.js
+++ b/bin/miyagi.js
@@ -1,2 +1,10 @@
 #!/usr/bin/env node
-import "../index.js";
+import runCli from "../index.js";
+
+const result = await runCli();
+
+if (result?.shouldExit) {
+	process.exit(result.code ?? 0);
+}
+
+process.exitCode = result?.code ?? 0;

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -4,3 +4,43 @@ eleventyNavigation:
 ---
 
 # CLI commands
+
+Use `miyagi <command>` if installed globally.
+
+If installed locally, use one of:
+
+```bash
+pnpm exec miyagi <command>
+yarn miyagi <command>
+npx miyagi <command>
+```
+
+## Commands
+
+| Command | Purpose | Docs |
+| ------- | ------- | ---- |
+| `miyagi start` | Start the local miyagi server | [Starting miyagi](/cli-commands/starting-miyagi/) |
+| `miyagi build` | Create a static build | [Creating a build](/cli-commands/creating-a-build/) |
+| `miyagi new` | Scaffold a new component | [Creating a component](/cli-commands/creating-a-component/) |
+| `miyagi mocks` | Generate mock data from a schema | [Creating mock data](/cli-commands/creating-mock-data/) |
+| `miyagi lint` | Validate schema files and mock data | [Linting mock data](/cli-commands/linting-mock-data/) |
+| `miyagi drupal-assets` | Resolve Drupal component assets into `$assets` | [Resolving Drupal assets](/cli-commands/resolving-drupal-assets/) |
+| `miyagi doctor` | Check config and environment for common setup issues | [Running doctor](/cli-commands/running-doctor/) |
+
+## Global options
+
+| Option | Purpose |
+| ------ | ------- |
+| `-h`, `--help` | Show command help |
+| `--version` | Print the installed miyagi version |
+| `-v`, `--verbose` | Enable extra log output |
+
+## Start-only options
+
+| Option | Purpose |
+| ------ | ------- |
+| `--watch-report` | Print startup watch report output |
+| `--watch-report-format pretty\|summary\|json` | Change watch report format |
+| `--watch-report-no-color` | Disable watch report colors |
+
+For watch report config details, see [`watch.report`](/configuration/options/#watch).

--- a/docs/cli-commands/creating-a-component.md
+++ b/docs/cli-commands/creating-a-component.md
@@ -1,7 +1,7 @@
 # Creating a component
 
 ```bash
-miyagi new <folderName>/<componentName>`
+miyagi new <folderName>/<componentName>
 ```
 
 This will create a component folder including the following files:
@@ -13,7 +13,7 @@ This will create a component folder including the following files:
 - `mocks`: mocks.json
 - `schema`: schema.json
 
-_**NOTE:** The component will be located based on your current working directoy (so you are able to use autocompletion) and the file names depend on your [`files` settings](/configuration/options#files)._
+_**NOTE:** The component will be located based on your current working directory, so you can use shell autocompletion. The file names depend on your [`files` settings](/configuration/options#files)._
 
 ## Params
 

--- a/docs/cli-commands/resolving-drupal-assets.md
+++ b/docs/cli-commands/resolving-drupal-assets.md
@@ -1,0 +1,41 @@
+# Resolving Drupal assets
+
+```bash
+miyagi drupal-assets
+```
+
+This command resolves Drupal `*.libraries.yml` dependencies and writes the flattened result to `$assets` in each component's mock file.
+
+## Options
+
+```bash
+miyagi drupal-assets [options]
+  --engine, -e       Engine to use (default: "drupal")
+  --config           Path to config file (default: .miyagi-assets.js)
+  --libraries, -l    Path to *.libraries.yml
+  --components, -c   Library names to process (space-separated)
+  --ignore-prefixes  Dependency prefixes to skip
+  --dry-run          Print resolved $assets without writing files
+```
+
+## Examples
+
+Preview changes first:
+
+```bash
+miyagi drupal-assets --dry-run
+```
+
+Process only specific libraries:
+
+```bash
+miyagi drupal-assets --components element-info-message element-button
+```
+
+Use a different libraries file:
+
+```bash
+miyagi drupal-assets --libraries subtheme.libraries.yml
+```
+
+For full setup, config, and examples, see [Drupal: Resolving component assets from libraries.yml](/recipes/drupal-component-assets/).

--- a/docs/cli-commands/running-doctor.md
+++ b/docs/cli-commands/running-doctor.md
@@ -1,0 +1,16 @@
+# Running doctor
+
+```bash
+miyagi doctor
+```
+
+This command checks common first-run issues:
+
+- Node.js version
+- miyagi config file presence
+- config parseability
+- `engine.render`
+- `components.folder` / `docs.folder`
+- existence of configured source folders
+
+Use it when `miyagi start` fails and you want a quick environment check before debugging further.

--- a/docs/cli-commands/starting-miyagi.md
+++ b/docs/cli-commands/starting-miyagi.md
@@ -5,10 +5,51 @@ eleventyNavigation:
 
 # Starting miyagi
 
-**Installed as a dev dependency:**
+Before starting miyagi, make sure you have:
+
+- a `.miyagi.js` or `.miyagi.mjs`
+- an `engine.render` function
+- at least one of `components.folder` or `docs.folder`
+
+## Quick start
+
+Twig example:
 
 ```bash
-pnpm miyagi start
+pnpm add -D @schalkneethling/miyagi-core twing
+```
+
+Create `.miyagi.mjs`:
+
+```js
+import { createSynchronousEnvironment, createSynchronousFilesystemLoader } from "twing";
+import fs from "node:fs";
+
+const twing = createSynchronousEnvironment(createSynchronousFilesystemLoader(fs));
+
+export default {
+  components: {
+    folder: "src/components",
+  },
+  docs: {
+    folder: "docs",
+  },
+  engine: {
+    async render({ name, context, cb }) {
+      try {
+        return cb(null, await twing.render(name, context));
+      } catch (err) {
+        return cb(err.toString());
+      }
+    },
+  },
+};
+```
+
+Then run:
+
+```bash
+pnpm exec miyagi start
 ```
 
 or
@@ -20,16 +61,16 @@ yarn miyagi start
 or
 
 ```bash
-npm run miyagi start
+npx miyagi start
 ```
 
-**Installed globally:**
+or, if installed globally:
 
 ```bash
 miyagi start
 ```
 
-This will serve _miyagi_ at `http://localhost:5000`. If you already have another _miyagi_ instance or some other application running at port 5000, _miyagi_ will automatically try to find another free port.
+This serves _miyagi_ at `http://localhost:5000`. If port `5000` is already in use, _miyagi_ automatically tries the next free port.
 
 ## Changing the port
 
@@ -38,3 +79,25 @@ PORT=<port> miyagi start
 ```
 
 _**NOTE:** Setting the `NODE_ENV` is optional (default is `development`), but it allows you to serve different assets based on your [configuration](/configuration/options#assets)._
+
+## Useful options
+
+```bash
+miyagi start --help
+miyagi start --watch-report
+miyagi start --watch-report-format json
+miyagi start --watch-report-no-color
+```
+
+See [`watch.report`](/configuration/options/#watch) for config-backed watch report settings.
+
+## Common first-run errors
+
+- `miyagi start` still fails and you want a quick checklist.
+  Run `miyagi doctor`.
+- `No render function has beend defined.`
+  Add `engine.render` to your miyagi config.
+- `Please specify at least either components.folder or docs.folder in your configuration file.`
+  Configure at least one source folder in `.miyagi.js` or `.miyagi.mjs`.
+- `miyagi wasn't able to find or parse your config file.`
+  Check that your config file exists and has valid syntax.

--- a/docs/cli-commands/using-verbose-mode.md
+++ b/docs/cli-commands/using-verbose-mode.md
@@ -1,3 +1,8 @@
 # Using verbose mode
 
-You can run all cli commands in verbose mode using `-v` or `--verbose`. This gives you additional information which might helpful especially in case of errors.
+You can run all CLI commands in verbose mode with `-v` or `--verbose`. This prints additional information, mainly useful when debugging errors.
+
+```bash
+miyagi start --verbose
+miyagi build -v
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,40 +5,51 @@ eleventyNavigation:
 
 # Installation
 
-**_miyagi_ can be installed from [npm](https://www.npmjs.com/package/@miyagi/core):**
+**_miyagi_ can be installed from [npm](https://www.npmjs.com/package/@schalkneethling/miyagi-core):**
 
 ```bash
-pnpm add -D @miyagi/core
+pnpm add -D @schalkneethling/miyagi-core
 ```
 
 or
 
 ```bash
-yarn add --dev @miyagi/core
+yarn add --dev @schalkneethling/miyagi-core
 ```
 
 or
 
 ```bash
-npm i --save-dev @miyagi/core
+npm i --save-dev @schalkneethling/miyagi-core
 ```
 
 **You can also install it globally:**
 
 ```bash
-pnpm add -g @miyagi/core
+pnpm add -g @schalkneethling/miyagi-core
 ```
 
 or
 
 ```bash
-yarn global add @miyagi/core
+yarn global add @schalkneethling/miyagi-core
 ```
 
 or
 
 ```bash
-npm i -g @miyagi/core
+npm i -g @schalkneethling/miyagi-core
 ```
 
 _**NOTE:** miyagi does not install any template engines for you, so you still need to install them manually._
+
+## First run
+
+After installing:
+
+1. Create `.miyagi.js` or `.miyagi.mjs`.
+2. Add an `engine.render` function.
+3. Configure at least one of `components.folder` or `docs.folder`.
+4. Start miyagi with `pnpm exec miyagi start`, `yarn miyagi start`, `npx miyagi start`, or `miyagi start` if installed globally.
+
+For a full example, see [Starting miyagi](/cli-commands/starting-miyagi/).

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-import Miyagi from "./lib/index.js";
+import { runCli } from "./lib/cli/run.js";
 
-export default await Miyagi();
+export default runCli;

--- a/lib/cli/component.js
+++ b/lib/cli/component.js
@@ -2,18 +2,24 @@ import generateComponent from "../generator/component.js";
 import log from "../logger.js";
 import appConfig from "../default-config.js";
 import { t } from "../i18n/index.js";
+import { EXIT_CODES } from "../errors.js";
 
 /**
  * @param {object} cliParams
- * @returns {Promise<void>}
+ * @returns {Promise<object>}
  */
 export default async function createComponentViaCli(cliParams) {
-	const commands = cliParams._.slice(1);
+	const commands = [cliParams.component].filter(Boolean);
 
 	if (commands.length === 0) {
-		log("error", t("generator.noComponentNameDefined"));
-
-		return;
+		const message = t("generator.noComponentNameDefined");
+		log("error", message);
+		return {
+			success: false,
+			code: EXIT_CODES.CLI_USAGE_ERROR,
+			shouldExit: true,
+			message,
+		};
 	}
 
 	const [component] = commands;
@@ -25,8 +31,20 @@ export default async function createComponentViaCli(cliParams) {
 	try {
 		const result = await generateComponent({ component, fileTypes });
 		log("success", result);
+		return {
+			success: true,
+			code: EXIT_CODES.SUCCESS,
+			shouldExit: true,
+			message: result,
+		};
 	} catch (message) {
 		log("error", message);
+		return {
+			success: false,
+			code: EXIT_CODES.GENERAL_ERROR,
+			shouldExit: true,
+			message: String(message),
+		};
 	}
 }
 

--- a/lib/cli/doctor.js
+++ b/lib/cli/doctor.js
@@ -1,0 +1,153 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import log from "../logger.js";
+import { EXIT_CODES } from "../errors.js";
+import pkgJson from "../../package.json" with { type: "json" };
+
+const CONFIG_FILES = [".miyagi.js", ".miyagi.mjs"];
+
+/**
+ * @returns {Promise<object>}
+ */
+export default async function doctor() {
+	let success = true;
+
+	if (checkNodeVersion()) {
+		log("success", `Node.js ${process.versions.node} satisfies ${pkgJson.engines.node}.`);
+	} else {
+		success = false;
+		log(
+			"error",
+			`Node.js ${process.versions.node} does not satisfy ${pkgJson.engines.node}.`,
+		);
+	}
+
+	const configResult = await loadUserConfig();
+
+	if (!configResult.userFileName) {
+		success = false;
+		log(
+			"error",
+			"No miyagi config found. Create .miyagi.js or .miyagi.mjs in your project root.",
+		);
+		return {
+			success,
+			code: EXIT_CODES.CONFIG_ERROR,
+			shouldExit: true,
+		};
+	}
+
+	if (configResult.error) {
+		success = false;
+		log(
+			"error",
+			`Could not parse ${configResult.userFileName}. Check its syntax and exports.`,
+		);
+		log("error", configResult.error.message, configResult.error);
+		return {
+			success,
+			code: EXIT_CODES.CONFIG_ERROR,
+			shouldExit: true,
+		};
+	}
+
+	log("success", `Loaded config from ${configResult.userFileName}.`);
+
+	const config = configResult.config || {};
+
+	if (typeof config.engine?.render === "function") {
+		log("success", "engine.render is defined.");
+	} else {
+		success = false;
+		log("error", "engine.render is missing.");
+	}
+
+	if (config.components?.folder || config.docs?.folder) {
+		log("success", "At least one source folder is configured.");
+	} else {
+		success = false;
+		log(
+			"error",
+			"Set at least one of components.folder or docs.folder in your miyagi config.",
+		);
+	}
+
+	if (config.components?.folder) {
+		if (await pathExists(config.components.folder)) {
+			log("success", `components.folder exists: ${config.components.folder}`);
+		} else {
+			success = false;
+			log("error", `components.folder does not exist: ${config.components.folder}`);
+		}
+	}
+
+	if (config.docs?.folder) {
+		if (await pathExists(config.docs.folder)) {
+			log("success", `docs.folder exists: ${config.docs.folder}`);
+		} else {
+			success = false;
+			log("error", `docs.folder does not exist: ${config.docs.folder}`);
+		}
+	}
+
+	log(success ? "success" : "error", success ? "Doctor checks passed." : "Doctor found issues.");
+
+	return {
+		success,
+		code: success ? EXIT_CODES.SUCCESS : EXIT_CODES.CONFIG_ERROR,
+		shouldExit: true,
+	};
+}
+
+/**
+ * @returns {boolean}
+ */
+function checkNodeVersion() {
+	const minimumMajor = Number(pkgJson.engines.node.match(/\d+/)?.[0] || 0);
+	const currentMajor = Number(process.versions.node.split(".")[0]);
+	return currentMajor >= minimumMajor;
+}
+
+/**
+ * @param {string} relativePath
+ * @returns {Promise<boolean>}
+ */
+async function pathExists(relativePath) {
+	try {
+		await stat(path.resolve(process.cwd(), relativePath));
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * @returns {Promise<object>}
+ */
+async function loadUserConfig() {
+	for (const fileName of CONFIG_FILES) {
+		const fullPath = path.resolve(process.cwd(), fileName);
+
+		if (!(await pathExists(fileName))) {
+			continue;
+		}
+
+		try {
+			const module = await import(`${fullPath}?time=${Date.now()}`);
+			return {
+				userFileName: fileName,
+				config: module.default || {},
+			};
+		} catch (error) {
+			return {
+				userFileName: fileName,
+				error: /** @type {Error} */ (error),
+			};
+		}
+	}
+
+	return {
+		userFileName: null,
+		config: null,
+	};
+}

--- a/lib/cli/drupal-assets.js
+++ b/lib/cli/drupal-assets.js
@@ -4,6 +4,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import yaml from "js-yaml";
 import log from "../logger.js";
+import { EXIT_CODES } from "../errors.js";
 import { loadAssetsConfig } from "../drupal/load-assets-config.js";
 import {
 	parseLibrariesYaml,
@@ -18,27 +19,47 @@ import {
 
 /**
  * @param {object} args - CLI arguments from yargs
+ * @returns {Promise<object>}
  */
 export default async function drupalAssets(args) {
 	let config;
 	try {
 		config = await loadAssetsConfig(args);
 	} catch (err) {
-		log("error", /** @type {Error} */ (err).message);
-		process.exit(1);
+		const message = /** @type {Error} */ (err).message;
+		log("error", message);
+		return {
+			success: false,
+			code: EXIT_CODES.CONFIG_ERROR,
+			shouldExit: true,
+			message,
+		};
 	}
 
 	if (!config.libraries) {
-		log("error", "No libraries file specified. Use --libraries or configure it in .miyagi-assets.js.");
-		process.exit(1);
+		const message =
+			"No libraries file specified. Use --libraries or configure it in .miyagi-assets.js.";
+		log("error", message);
+		return {
+			success: false,
+			code: EXIT_CODES.CLI_USAGE_ERROR,
+			shouldExit: true,
+			message,
+		};
 	}
 
 	let yamlContent;
 	try {
 		yamlContent = await readFile(config.libraries, "utf8");
 	} catch {
-		log("error", `Could not read libraries file: ${config.libraries}`);
-		process.exit(1);
+		const message = `Could not read libraries file: ${config.libraries}`;
+		log("error", message);
+		return {
+			success: false,
+			code: EXIT_CODES.CONFIG_ERROR,
+			shouldExit: true,
+			message,
+		};
 	}
 
 	const librariesMap = parseLibrariesYaml(yamlContent);
@@ -89,8 +110,24 @@ export default async function drupalAssets(args) {
 	}
 
 	if (!config.dryRun) {
-		log("success", `Done. Updated ${updatedCount} component(s).`);
+		const message = `Done. Updated ${updatedCount} component(s).`;
+		log("success", message);
+		return {
+			success: true,
+			code: EXIT_CODES.SUCCESS,
+			shouldExit: true,
+			message,
+			updatedCount,
+		};
 	}
+
+	return {
+		success: true,
+		code: EXIT_CODES.SUCCESS,
+		shouldExit: true,
+		message: "Dry run completed.",
+		updatedCount,
+	};
 }
 
 /**

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -1,7 +1,9 @@
 import lintImport from "./lint.js";
 import componentImport from "./component.js";
 import drupalAssetsImport from "./drupal-assets.js";
+import doctorImport from "./doctor.js";
 
 export const lint = lintImport;
 export const component = componentImport;
 export const drupalAssets = drupalAssetsImport;
+export const doctor = doctorImport;

--- a/lib/cli/lint.js
+++ b/lib/cli/lint.js
@@ -10,14 +10,16 @@ import {
 	validateSchemas,
 } from "../validator/schemas.js";
 import { t } from "../i18n/index.js";
+import { EXIT_CODES } from "../errors.js";
 
 /**
  * @param {object} args
+ * @returns {Promise<object>}
  */
 export default async function lint(args) {
 	process.env.NODE_ENV = "development";
 
-	const componentArg = args._.slice(1)[0];
+	const componentArg = args.component;
 	const config = await getConfig(args);
 	process.env.MIYAGI_LOG_CONTEXT = "lint";
 	process.env.MIYAGI_LOG_LEVEL = config.lint?.logLevel || "error";
@@ -36,26 +38,63 @@ export default async function lint(args) {
 
 			if (schemaValidation.errors.length > 0) {
 				reportSchemaErrors(schemaValidation.errors);
-				process.exit(1);
+				return {
+					success: false,
+					code: EXIT_CODES.VALIDATION_ERROR,
+					shouldExit: true,
+				};
 			}
 
 			log("success", "All schemas valid.");
 
-			await validateComponentMockData({
+			return await validateComponentMockData({
 				component,
 				validSchemas: schemaValidation.validSchemas,
 			});
 		} else {
-			log("error", `The component ${componentArg} does not seem to exist.`);
-			process.exit(1);
+			const message = `The component ${componentArg} does not seem to exist.`;
+			log("error", message);
+			return {
+				success: false,
+				code: EXIT_CODES.CLI_USAGE_ERROR,
+				shouldExit: true,
+				message,
+			};
 		}
 	} else {
-		await validateAllMockData();
+		return await validateAllMockData();
 	}
 }
 
 /**
+ * @param {object} options
+ * @param {boolean} options.success
+ * @param {boolean} options.shouldExit
+ * @param {boolean} [options.valid]
+ * @param {string} [options.type]
+ * @returns {object}
+ */
+function createLintResult({ success, shouldExit, valid, type }) {
+	const result = {
+		success,
+		code: success ? EXIT_CODES.SUCCESS : EXIT_CODES.VALIDATION_ERROR,
+		shouldExit,
+	};
+
+	if (valid !== undefined) {
+		result.valid = valid;
+	}
+
+	if (type) {
+		result.type = type;
+	}
+
+	return result;
+}
+
+/**
  * @param {boolean} exitProcess
+ * @returns {Promise<object>}
  */
 async function validateAllMockData(exitProcess = true) {
 	log("info", t("linter.all.start"));
@@ -86,9 +125,17 @@ async function validateAllMockData(exitProcess = true) {
 					),
 		);
 		if (exitProcess) {
-			process.exit(1);
+			return {
+				success: false,
+				code: EXIT_CODES.VALIDATION_ERROR,
+				shouldExit: true,
+			};
 		}
-		return;
+		return {
+			success: false,
+			code: EXIT_CODES.VALIDATION_ERROR,
+			shouldExit: false,
+		};
 	}
 
 	const results = await Promise.all(
@@ -134,15 +181,16 @@ async function validateAllMockData(exitProcess = true) {
 
 	if (mockInvalidResults.length === 0 && schemaValidation.errors.length === 0) {
 		log("success", t("linter.all.valid"));
-		if (exitProcess) {
-			process.exit(0);
-		}
-		return;
+		return createLintResult({
+			success: true,
+			shouldExit: exitProcess,
+		});
 	}
 
-	if (exitProcess) {
-		process.exit(1);
-	}
+	return createLintResult({
+		success: false,
+		shouldExit: exitProcess,
+	});
 }
 
 /**
@@ -188,23 +236,19 @@ async function validateComponentMockData({
 			log("success", t("linter.component.valid"));
 		}
 
-		if (exitProcess) {
-			process.exit(0);
-		}
-
-		return {
+		return createLintResult({
 			valid: true,
-		};
+			success: true,
+			shouldExit: exitProcess,
+		});
 	}
 
-	if (exitProcess) {
-		process.exit(1);
-	}
-
-	return {
+	return createLintResult({
 		valid: false,
+		success: false,
+		shouldExit: exitProcess,
 		type: results[0].type,
-	};
+	});
 }
 
 /**

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -1,0 +1,281 @@
+import { t } from "../i18n/index.js";
+import initRendering from "../init/rendering.js";
+import log from "../logger.js";
+import mockGenerator from "../generator/mocks.js";
+import getConfig from "../config.js";
+import createCli from "../init/args.js";
+import {
+	lint,
+	component as createComponentViaCli,
+	drupalAssets,
+	doctor,
+} from "./index.js";
+import { EXIT_CODES, MiyagiError } from "../errors.js";
+
+/**
+ * @returns {object}
+ */
+function createSuccessResult() {
+	return {
+		success: true,
+		code: EXIT_CODES.SUCCESS,
+		shouldExit: true,
+	};
+}
+
+/**
+ * @param {string} message
+ * @param {number} [code]
+ * @returns {object}
+ */
+function createFailureResult(message, code = EXIT_CODES.GENERAL_ERROR) {
+	log("error", message);
+	return {
+		success: false,
+		code,
+		shouldExit: true,
+		message,
+	};
+}
+
+/**
+ * @param {number} code
+ * @param {string[]} argv
+ * @returns {void}
+ */
+function maybeLogDoctorHint(code, argv) {
+	if (code !== EXIT_CODES.CONFIG_ERROR) {
+		return;
+	}
+
+	if (argv.includes("doctor")) {
+		return;
+	}
+
+	log("info", "Run `miyagi doctor` for a setup check.");
+}
+
+/**
+ * @param {object} args
+ * @param {boolean} [isBuild]
+ * @param {boolean} [isComponentGenerator]
+ * @returns {Promise<object>}
+ */
+async function loadCliConfig(args, isBuild = false, isComponentGenerator = false) {
+	global.config = await getConfig(args, isBuild, isComponentGenerator);
+
+	if (!global.config.components.folder && !global.config.docs.folder) {
+		return createFailureResult(
+			"Please specify at least either components.folder or docs.folder in your configuration file.",
+			EXIT_CODES.CONFIG_ERROR,
+		);
+	}
+
+	return {
+		success: true,
+		config: global.config,
+	};
+}
+
+/**
+ * @param {object} args
+ * @returns {void}
+ */
+function applyCliEnv(args) {
+	if (args.verbose) {
+		process.env.VERBOSE = String(args.verbose);
+	}
+}
+
+/**
+ * @param {object} args
+ * @param {object} [options]
+ * @param {string} [options.defaultNodeEnv]
+ * @param {string} [options.forcedNodeEnv]
+ * @param {boolean} [options.isBuild]
+ * @param {boolean} [options.isComponentGenerator]
+ * @param {Function} run
+ * @returns {Promise<object>}
+ */
+async function withCliConfig(args, options = {}, run) {
+	applyCliEnv(args);
+
+	if (options.forcedNodeEnv) {
+		process.env.NODE_ENV = options.forcedNodeEnv;
+	} else if (options.defaultNodeEnv && !process.env.NODE_ENV) {
+		process.env.NODE_ENV = options.defaultNodeEnv;
+	}
+
+	const configResult = await loadCliConfig(
+		args,
+		options.isBuild,
+		options.isComponentGenerator,
+	);
+	if (!configResult.success) {
+		return configResult;
+	}
+
+	return await run(configResult.config);
+}
+
+/**
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+async function runStartCommand(args) {
+	return await withCliConfig(
+		args,
+		{ defaultNodeEnv: "development" },
+		async (config) => {
+			log(
+				"info",
+				t("serverStarting").replace("{{node_env}}", process.env.NODE_ENV),
+			);
+
+			return await initRendering(config);
+		},
+	);
+}
+
+/**
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+async function runBuildCommand(args) {
+	return await withCliConfig(
+		args,
+		{ forcedNodeEnv: "production", isBuild: true },
+		async (config) => {
+			log("info", t("buildStarting"));
+			return await initRendering(config);
+		},
+	);
+}
+
+/**
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+async function runComponentCommand(args) {
+	return await withCliConfig(
+		args,
+		{ defaultNodeEnv: "development", isComponentGenerator: true },
+		async () => {
+			log("info", t("generator.starting"));
+			return await createComponentViaCli(args);
+		},
+	);
+}
+
+/**
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+async function runMocksCommand(args) {
+	return await withCliConfig(
+		args,
+		{ defaultNodeEnv: "development" },
+		async (config) => {
+			const result = await mockGenerator(args.component, config.files);
+			if (result?.message) {
+				log(result.message.type, result.message.text, result.message.verbose);
+			}
+
+			return {
+				success: result.success,
+				code: result.success ? EXIT_CODES.SUCCESS : EXIT_CODES.GENERAL_ERROR,
+				shouldExit: true,
+				message: result.message?.text,
+			};
+		},
+	);
+}
+
+/**
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+async function runLintCommand(args) {
+	applyCliEnv(args);
+	return await lint(args);
+}
+
+/**
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+async function runDrupalAssetsCommand(args) {
+	return await withCliConfig(
+		args,
+		{ forcedNodeEnv: "development" },
+		async () => await drupalAssets(args),
+	);
+}
+
+/**
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+async function runDoctorCommand(args) {
+	applyCliEnv(args);
+	return await doctor(args);
+}
+
+/**
+ * @param {Error|MiyagiError|string} error
+ * @param {string[]} argv
+ * @returns {object}
+ */
+function normalizeCliError(error, argv) {
+	if (error instanceof MiyagiError) {
+		if (!error.logged) {
+			log("error", error.message);
+		}
+		maybeLogDoctorHint(error.code, argv);
+
+		return {
+			success: false,
+			code: error.code,
+			shouldExit: true,
+			message: error.message,
+		};
+	}
+
+	const message = error instanceof Error ? error.message : String(error);
+	log("error", message);
+	maybeLogDoctorHint(EXIT_CODES.GENERAL_ERROR, argv);
+	return {
+		success: false,
+		code: EXIT_CODES.GENERAL_ERROR,
+		shouldExit: true,
+		message,
+	};
+}
+
+/**
+ * @param {string[]} [argv]
+ * @returns {Promise<object>}
+ */
+export async function runCli(argv = process.argv) {
+	const { cli, getResult } = createCli(
+		{
+			start: runStartCommand,
+			build: runBuildCommand,
+			new: runComponentCommand,
+			mocks: runMocksCommand,
+			lint: runLintCommand,
+			drupalAssets: runDrupalAssetsCommand,
+			doctor: runDoctorCommand,
+		},
+		argv,
+	);
+
+	try {
+		await cli.parseAsync();
+		const result = getResult() || createSuccessResult();
+		maybeLogDoctorHint(result.code, argv);
+		return result;
+	} catch (error) {
+		return normalizeCliError(error, argv);
+	}
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -62,6 +62,16 @@ function getCliArgs(args) {
 
 	delete cliArgs._;
 	delete cliArgs.$0;
+	delete cliArgs.component;
+	delete cliArgs.verbose;
+	delete cliArgs.skip;
+	delete cliArgs.only;
+	delete cliArgs.engine;
+	delete cliArgs.config;
+	delete cliArgs.libraries;
+	delete cliArgs.components;
+	delete cliArgs.ignorePrefixes;
+	delete cliArgs.dryRun;
 
 	if (cliArgs.folder) {
 		buildArgs.folder = cliArgs.folder;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,31 @@
+/**
+ * CLI/process exit codes used by miyagi.
+ *
+ * Keep this list small and coarse-grained. The goal is predictable automation,
+ * not a unique code for every possible failure.
+ */
+export const EXIT_CODES = Object.freeze({
+	SUCCESS: 0,
+	GENERAL_ERROR: 1,
+	CLI_USAGE_ERROR: 2,
+	CONFIG_ERROR: 3,
+	VALIDATION_ERROR: 4,
+});
+
+export class MiyagiError extends Error {
+	/**
+	 * @param {string} message
+	 * @param {object} [options]
+	 * @param {number} [options.code] Exit code from `EXIT_CODES`.
+	 * @param {boolean} [options.logged] True if this error was already sent to the logger and should not be logged again at the CLI boundary.
+	 */
+	constructor(
+		message,
+		{ code = EXIT_CODES.GENERAL_ERROR, logged = false } = {},
+	) {
+		super(message);
+		this.name = "MiyagiError";
+		this.code = code;
+		this.logged = logged;
+	}
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,80 +6,10 @@
  */
 
 import { t } from "./i18n/index.js";
-import initRendering from "./init/rendering.js";
 import log from "./logger.js";
-import yargs from "./init/args.js";
-import mockGenerator from "./generator/mocks.js";
 import getConfig from "./config.js";
-import {
-	lint,
-	component as createComponentViaCli,
-	drupalAssets,
-} from "./cli/index.js";
+import { EXIT_CODES } from "./errors.js";
 import apiApp from "../api/app.js";
-
-/**
- * Checks if miyagi was started with "mocks" command
- * @param {object} args - the cli args
- * @returns {boolean} is true if the miyagi was started with "mocks"
- */
-function argsIncludeMockGenerator(args) {
-	return args._.includes("mocks");
-}
-
-/**
- * Checks if miyagi was started with "new" command
- * @param {object} args - the cli args
- * @returns {boolean} is true if the miyagi was started with "new"
- */
-function argsIncludeComponentGenerator(args) {
-	return args._.includes("new");
-}
-
-/**
- * Checks if miyagi was started with "build" command
- * @param {object} args - the cli args
- * @returns {boolean} is true if the miyagi was started with "new"
- */
-function argsIncludeBuild(args) {
-	return args._.includes("build");
-}
-
-/**
- * Checks if miyagi was started with "start" command
- * @param {object} args - the cli args
- * @returns {boolean} is true if the miyagi was started with "start"
- */
-function argsIncludeServer(args) {
-	return args._.includes("start");
-}
-
-/**
- * Checks if miyagi was started with "lint" command
- * @param {object} args
- * @returns {boolean}
- */
-function argsIncludeLint(args) {
-	return args._.includes("lint");
-}
-
-/**
- * @param {object} args
- * @returns {boolean}
- */
-function argsIncludeDrupalAssets(args) {
-	return args._.includes("drupal-assets");
-}
-
-/**
- * Runs the mock generator
- * @param {object} config - the user configuration object
- * @param {object} args - the cli args
- * @returns {Promise}
- */
-function runMockGenerator(config, args) {
-	return mockGenerator(args._.slice(1)[0], config.files).catch(() => {});
-}
 
 /**
  * @param {object} config
@@ -105,85 +35,11 @@ export default async function Miyagi(cmd, { isBuild: isApiBuild } = {}) {
 		return await initApi(global.config);
 	}
 
-	let args;
-	let isServer;
-	let isBuild;
-	let isComponentGenerator;
-	let isMockGenerator;
-	let isLinter;
-	let isDrupalAssets;
-
-	if (cmd) {
-		isBuild = cmd === "build";
-	} else {
-		args = await yargs.argv;
-		isServer = argsIncludeServer(args);
-		isBuild = argsIncludeBuild(args);
-		isComponentGenerator = argsIncludeComponentGenerator(args);
-		isMockGenerator = argsIncludeMockGenerator(args);
-		isLinter = argsIncludeLint(args);
-		isDrupalAssets = argsIncludeDrupalAssets(args);
-	}
-
-	if (args && args.verbose) {
-		process.env.VERBOSE = String(args.verbose);
-	}
-
-	if (isLinter) {
-		return lint(args);
-	}
-
-	if (isDrupalAssets) {
-		process.env.NODE_ENV = "development";
-		global.config = await getConfig(args);
-		await drupalAssets(args);
-		process.exit();
-	}
-
-	if (isBuild || isComponentGenerator || isServer || isMockGenerator) {
-		if (isBuild) {
-			process.env.NODE_ENV = "production";
-			log("info", t("buildStarting"));
-		} else {
-			if (!process.env.NODE_ENV) {
-				process.env.NODE_ENV = "development";
-			}
-
-			if (isComponentGenerator) {
-				log("info", t("generator.starting"));
-			} else if (isServer) {
-				log(
-					"info",
-					t("serverStarting").replace("{{node_env}}", process.env.NODE_ENV),
-				);
-			}
-		}
-
-		global.config = await getConfig(args, isBuild, isComponentGenerator);
-
-		if (!global.config.components.folder && !global.config.docs.folder) {
-			log(
-				"error",
-				"Please specify at least either components.folder or docs.folder in your configuration file.",
-			);
-			process.exit(1);
-		}
-
-		if (isMockGenerator) {
-			await runMockGenerator(global.config, args);
-			// Force-exit in case imported user config has active resources preventing Node.js from exiting.
-			process.exit();
-		}
-
-		if (isComponentGenerator) {
-			await createComponentViaCli(args);
-			// Force-exit in case imported user config has active resources preventing Node.js from exiting.
-			process.exit();
-		}
-
-		return initRendering(global.config);
-	}
-
 	log("error", t("commandNotFound"));
-	process.exit(1);
+	return {
+		success: false,
+		code: EXIT_CODES.CLI_USAGE_ERROR,
+		shouldExit: true,
+		message: t("commandNotFound"),
+	};
 }

--- a/lib/init/args.js
+++ b/lib/init/args.js
@@ -6,101 +6,169 @@
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import pkgJson from "../../package.json" with { type: "json" };
+import { EXIT_CODES, MiyagiError } from "../errors.js";
 
-export default yargs(hideBin(process.argv))
-	.command("start", "Starts the miyagi server", {
-		verbose: {
+/**
+ * @param {object} handlers
+ * @param {string[]} [argv]
+ * @returns {object}
+ */
+export default function createCli(handlers, argv = process.argv) {
+	let result;
+
+	const commandHandler = (handler) => async (args) => {
+		result = await handler(args);
+		return result;
+	};
+
+	const cli = yargs(hideBin(argv))
+		.scriptName("miyagi")
+		.option("verbose", {
+			alias: "v",
 			description:
 				"Logging additional information — helpful mainly in case of errors.",
 			type: "boolean",
+			global: true,
+		})
+		.command(
+			"start",
+			"Starts the miyagi server",
+			(builder) =>
+				builder
+					.option("watch-report", {
+						description: "Enable watch report output on startup.",
+						type: "boolean",
+					})
+					.option("watch-report-format", {
+						description: "Set watch report format.",
+						type: "string",
+						choices: ["pretty", "summary", "json"],
+					})
+					.option("watch-report-no-color", {
+						description: "Disable colors in watch report output.",
+						type: "boolean",
+					}),
+			commandHandler(handlers.start),
+		)
+		.command(
+			"build",
+			"Creates a static build of all your components",
+			(builder) =>
+				builder.option("folder", {
+					description: "The folder where your static build files will be saved",
+					type: "string",
+				}),
+			commandHandler(handlers.build),
+		)
+		.command(
+			"new <component>",
+			"Creates a new component folder (including template, CSS, JS, documentation, mocks, and schema files)",
+			(builder) =>
+				builder
+					.positional("component", {
+						description: "The component path to create",
+						type: "string",
+					})
+					.option("skip", {
+						description:
+							"files that will not be created\n(space separated list of tpl, css, js, docs, mocks, schema)",
+						type: "array",
+					})
+					.option("only", {
+						description:
+							"tells miyagi to only created the passes file types\n(space separated list of tpl, css, js, docs, mocks, schema)",
+						type: "array",
+					}),
+			commandHandler(handlers.new),
+		)
+		.command(
+			"mocks <component>",
+			"Creates a mock data file with dummy content based on the schema file",
+			(builder) =>
+				builder.positional("component", {
+					description: "The component path to generate mock data for",
+					type: "string",
+				}),
+			commandHandler(handlers.mocks),
+		)
+		.command(
+			"lint [component]",
+			"Validates if the component's mock data matches its JSON schema",
+			(builder) =>
+				builder.positional("component", {
+					description: "Optional component path to lint",
+					type: "string",
+				}),
+			commandHandler(handlers.lint),
+		)
+		.command(
+			"drupal-assets",
+			"Resolves Drupal *.libraries.yml dependencies and updates component $assets in mock files",
+			(builder) =>
+				builder
+					.option("engine", {
+						alias: "e",
+						description: "Engine to use for asset resolution",
+						type: "string",
+						choices: ["drupal"],
+						default: "drupal",
+					})
+					.option("config", {
+						description: "Path to .miyagi-assets.js config file",
+						type: "string",
+						default: ".miyagi-assets.js",
+					})
+					.option("libraries", {
+						alias: "l",
+						description: "Path to *.libraries.yml (overrides config)",
+						type: "string",
+					})
+					.option("components", {
+						alias: "c",
+						description: "Library names to process (space-separated)",
+						type: "array",
+					})
+					.option("ignore-prefixes", {
+						description:
+							'Dependency prefixes to skip (e.g. "core" to ignore core/jquery)',
+						type: "array",
+					})
+					.option("dry-run", {
+						description: "Print resolved $assets without writing files",
+						type: "boolean",
+						default: false,
+					}),
+			commandHandler(handlers.drupalAssets),
+		)
+		.command(
+			"doctor",
+			"Checks your miyagi environment and config for common setup issues",
+			() => {},
+			commandHandler(handlers.doctor),
+		)
+		.help()
+		.version(pkgJson.version)
+		.alias("help", "h")
+		.strictCommands()
+		.demandCommand()
+		.exitProcess(false)
+		.fail((message, error) => {
+			if (error) {
+				throw error;
+			}
+
+			throw new MiyagiError(message || "CLI parsing failed.", {
+				code: EXIT_CODES.CLI_USAGE_ERROR,
+			});
+		})
+		.epilogue(
+			"Please check https://docs.miyagi.dev/configuration/options/ for all options",
+		);
+
+	return {
+		cli,
+		getResult() {
+			return result;
 		},
-		"watch-report": {
-			description: "Enable watch report output on startup.",
-			type: "boolean",
-		},
-		"watch-report-format": {
-			description: "Set watch report format.",
-			type: "string",
-			choices: ["pretty", "summary", "json"],
-		},
-		"watch-report-no-color": {
-			description: "Disable colors in watch report output.",
-			type: "boolean",
-		},
-	})
-	.command("build", "Creates a static build of all your components", {
-		folder: {
-			description: "The folder where your static build files will be saved",
-			type: "string",
-		},
-	})
-	.command(
-		"new",
-		"Creates a new component folder (including template, CSS, JS, documentation, mocks, and schema files)",
-		{
-			skip: {
-				description:
-					"files that will not be created\n(space separated list of tpl, css, js, docs, mocks, schema)",
-				type: "array",
-			},
-			only: {
-				description:
-					"tells miyagi to only created the passes file types\n(space separated list of tpl, css, js, docs, mocks, schema)",
-				type: "array",
-			},
-		},
-	)
-	.command(
-		"mocks",
-		"Creates a mock data file with dummy content based on the schema file",
-	)
-	.command(
-		"lint",
-		"Validates if the component's mock data matches its JSON schema",
-	)
-	.command(
-		"drupal-assets",
-		"Resolves Drupal *.libraries.yml dependencies and updates component $assets in mock files",
-		{
-			engine: {
-				alias: "e",
-				description: "Engine to use for asset resolution",
-				type: "string",
-				choices: ["drupal"],
-				default: "drupal",
-			},
-			config: {
-				description: "Path to .miyagi-assets.js config file",
-				type: "string",
-				default: ".miyagi-assets.js",
-			},
-			libraries: {
-				alias: "l",
-				description: "Path to *.libraries.yml (overrides config)",
-				type: "string",
-			},
-			components: {
-				alias: "c",
-				description: "Library names to process (space-separated)",
-				type: "array",
-			},
-			"ignore-prefixes": {
-				description:
-					'Dependency prefixes to skip (e.g. "core" to ignore core/jquery)',
-				type: "array",
-			},
-			"dry-run": {
-				description: "Print resolved $assets without writing files",
-				type: "boolean",
-				default: false,
-			},
-		},
-	)
-	.help()
-	.version(pkgJson.version)
-	.alias("help", "h")
-	.alias("verbose", "v")
-	.demandCommand()
-	.epilogue(
-		"Please check https://docs.miyagi.dev/configuration/options/ for all options",
-	);
+	};
+}

--- a/lib/init/engines.js
+++ b/lib/init/engines.js
@@ -7,6 +7,7 @@ import fs from "fs";
 import { t } from "../i18n/index.js";
 import log from "../logger.js";
 import * as helpers from "../helpers.js";
+import { EXIT_CODES, MiyagiError } from "../errors.js";
 import TwingCache from "./twing/cache.js";
 import * as twingFunctions from "./twing/functions.js";
 
@@ -41,8 +42,12 @@ async function setUserEngine() {
 	const { engine } = global.config;
 
 	if (!engine.render) {
-		log("error", "No render function has beend defined.");
-		process.exit(1);
+		const message = "No render function has beend defined.";
+		log("error", message);
+		throw new MiyagiError(message, {
+			code: EXIT_CODES.CONFIG_ERROR,
+			logged: true,
+		});
 	}
 
 	try {
@@ -51,8 +56,12 @@ async function setUserEngine() {
 			async (name, context, cb) => await engine.render({ name, context, cb }),
 		);
 	} catch (e) {
-		log("error", t("settingEngineFailed"), e);
-		process.exit(1);
+		const message = t("settingEngineFailed");
+		log("error", message, e);
+		throw new MiyagiError(message, {
+			code: EXIT_CODES.CONFIG_ERROR,
+			logged: true,
+		});
 	}
 }
 

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -12,6 +12,7 @@ import appConfig from "../default-config.js";
 import { t } from "../i18n/index.js";
 import build from "../build/index.js";
 import log from "../logger.js";
+import { EXIT_CODES } from "../errors.js";
 import setEngines from "./engines.js";
 import setRouter from "./router.js";
 import setState from "../state/index.js";
@@ -50,15 +51,24 @@ export default async function init(mergedConfig) {
 	setViews();
 
 	if (global.config.isBuild) {
-		return build()
-			.then((message) => {
-				log("success", message);
-				process.exit(0);
-			})
-			.catch((error) => {
-				log("error", error);
-				process.exit(1);
-			});
+		try {
+			const message = await build();
+			log("success", message);
+			return {
+				success: true,
+				code: EXIT_CODES.SUCCESS,
+				shouldExit: true,
+				message,
+			};
+		} catch (error) {
+			log("error", error);
+			return {
+				success: false,
+				code: EXIT_CODES.GENERAL_ERROR,
+				shouldExit: true,
+				message: String(error),
+			};
+		}
 	}
 
 	const { server, port: actualPort } = await startServer(
@@ -69,7 +79,13 @@ export default async function init(mergedConfig) {
 
 	log("success", `${t("serverStarted").replace("{{port}}", actualPort)}\n`);
 
-	return server;
+	return {
+		success: true,
+		code: EXIT_CODES.SUCCESS,
+		shouldExit: false,
+		server,
+		port: actualPort,
+	};
 }
 
 /**

--- a/lib/state/helpers.js
+++ b/lib/state/helpers.js
@@ -7,6 +7,7 @@ import path from "path";
 import log from "../logger.js";
 import { t } from "../i18n/index.js";
 import { readdir } from "node:fs/promises";
+import { EXIT_CODES, MiyagiError } from "../errors.js";
 
 /**
  * @param {string|null} dir - the directory in which to look for files
@@ -25,17 +26,21 @@ async function getFiles(dir, ignores, configPath, type, check) {
 		});
 	} catch (error) {
 		if (error.code === "ENOENT") {
-			log(
-				"error",
-				t("srcFolderNotFound")
-					.replaceAll("{{directory}}", dir)
-					.replaceAll("{{type}}", type)
-					.replaceAll("{{config}}", configPath),
-			);
-			process.exit(1);
+			const message = t("srcFolderNotFound")
+				.replaceAll("{{directory}}", dir)
+				.replaceAll("{{type}}", type)
+				.replaceAll("{{config}}", configPath);
+			log("error", message);
+			throw new MiyagiError(message, {
+				code: EXIT_CODES.CONFIG_ERROR,
+				logged: true,
+			});
 		} else {
 			log("error", error.toString(), error);
-			process.exit(1);
+			throw new MiyagiError(error.toString(), {
+				code: EXIT_CODES.GENERAL_ERROR,
+				logged: true,
+			});
 		}
 	}
 

--- a/tests/bin/miyagi.test.js
+++ b/tests/bin/miyagi.test.js
@@ -1,0 +1,16 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+describe("bin/miyagi.js", () => {
+	test("prints help and exits successfully", () => {
+		const result = spawnSync(process.execPath, [path.join("bin", "miyagi.js"), "--help"], {
+			cwd: path.join(import.meta.dirname, "../.."),
+			encoding: "utf8",
+		});
+
+		expect(result.status).toBe(0);
+		expect(result.stdout).toContain("start");
+		expect(result.stdout).toContain("drupal-assets");
+	});
+});

--- a/tests/lib/cli/doctor.test.js
+++ b/tests/lib/cli/doctor.test.js
@@ -1,0 +1,71 @@
+import { mkdtempDisposable, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import doctor from "../../../lib/cli/doctor.js";
+import { EXIT_CODES } from "../../../lib/errors.js";
+
+describe("doctor", () => {
+	let tmpDir;
+	let tmpDirHandle;
+	let previousCwd;
+
+	beforeEach(async () => {
+		previousCwd = process.cwd();
+		tmpDirHandle = await mkdtempDisposable(
+			path.join(os.tmpdir(), "miyagi-doctor-"),
+		);
+		tmpDir = tmpDirHandle.path;
+		process.chdir(tmpDir);
+	});
+
+	afterEach(async () => {
+		process.chdir(previousCwd);
+		await tmpDirHandle.remove();
+	});
+
+	test("passes for a valid config", async () => {
+		await mkdir(path.join(tmpDir, "src/components"), { recursive: true });
+		await mkdir(path.join(tmpDir, "docs"), { recursive: true });
+		await writeFile(
+			path.join(tmpDir, ".miyagi.mjs"),
+			`export default {
+  components: { folder: "src/components" },
+  docs: { folder: "docs" },
+  engine: {
+    render({ cb }) {
+      return cb(null, "");
+    }
+  }
+};
+`,
+		);
+
+		const result = await doctor();
+
+		expect(result).toStrictEqual({
+			success: true,
+			code: EXIT_CODES.SUCCESS,
+			shouldExit: true,
+		});
+	});
+
+	test("fails when engine.render is missing", async () => {
+		await mkdir(path.join(tmpDir, "src/components"), { recursive: true });
+		await writeFile(
+			path.join(tmpDir, ".miyagi.mjs"),
+			`export default {
+  components: { folder: "src/components" }
+};
+`,
+		);
+
+		const result = await doctor();
+
+		expect(result).toStrictEqual({
+			success: false,
+			code: EXIT_CODES.CONFIG_ERROR,
+			shouldExit: true,
+		});
+	});
+});

--- a/tests/lib/cli/run.test.js
+++ b/tests/lib/cli/run.test.js
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { EXIT_CODES, MiyagiError } from "../../../lib/errors.js";
+
+const {
+	mockInitRendering,
+	mockGetConfig,
+	mockMockGenerator,
+	mockLint,
+	mockComponent,
+	mockDrupalAssets,
+	mockDoctor,
+	mockLog,
+} = vi.hoisted(() => ({
+	mockInitRendering: vi.fn(),
+	mockGetConfig: vi.fn(),
+	mockMockGenerator: vi.fn(),
+	mockLint: vi.fn(),
+	mockComponent: vi.fn(),
+	mockDrupalAssets: vi.fn(),
+	mockDoctor: vi.fn(),
+	mockLog: vi.fn(),
+}));
+
+vi.mock("../../../lib/init/rendering.js", () => ({
+	default: mockInitRendering,
+}));
+
+vi.mock("../../../lib/config.js", () => ({
+	default: mockGetConfig,
+}));
+
+vi.mock("../../../lib/generator/mocks.js", () => ({
+	default: mockMockGenerator,
+}));
+
+vi.mock("../../../lib/cli/index.js", () => ({
+	lint: mockLint,
+	component: mockComponent,
+	drupalAssets: mockDrupalAssets,
+	doctor: mockDoctor,
+}));
+
+vi.mock("../../../lib/logger.js", () => ({
+	default: mockLog,
+}));
+
+import { runCli } from "../../../lib/cli/run.js";
+
+describe("runCli", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		delete process.env.NODE_ENV;
+		delete process.env.VERBOSE;
+		global.config = undefined;
+		mockGetConfig.mockResolvedValue({
+			components: {
+				folder: "src/components",
+			},
+			docs: {
+				folder: "docs",
+			},
+			files: {
+				mocks: {
+					name: "mocks",
+					extension: ["json"],
+				},
+				schema: {
+					name: "schema",
+					extension: "json",
+				},
+			},
+		});
+	});
+
+	test("returns rendering result for start", async () => {
+		mockInitRendering.mockResolvedValue({
+			success: true,
+			code: 0,
+			shouldExit: false,
+			port: 5000,
+		});
+
+		const result = await runCli(["node", "miyagi", "start", "--verbose"]);
+
+		expect(mockGetConfig).toHaveBeenCalled();
+		expect(mockInitRendering).toHaveBeenCalledWith(
+			expect.objectContaining({
+				components: expect.objectContaining({
+					folder: "src/components",
+				}),
+			}),
+		);
+		expect(process.env.NODE_ENV).toBe("development");
+		expect(process.env.VERBOSE).toBe("true");
+		expect(result).toStrictEqual({
+			success: true,
+			code: EXIT_CODES.SUCCESS,
+			shouldExit: false,
+			port: 5000,
+		});
+	});
+
+	test("maps mock generator failures to exit code 1", async () => {
+		mockMockGenerator.mockResolvedValue({
+			success: false,
+			message: {
+				type: "error",
+				text: "No schema file.",
+			},
+		});
+
+		const result = await runCli(["node", "miyagi", "mocks", "atoms/button"]);
+
+		expect(mockMockGenerator).toHaveBeenCalledWith(
+			"atoms/button",
+			expect.objectContaining({
+				mocks: expect.any(Object),
+			}),
+		);
+		expect(result).toStrictEqual({
+			success: false,
+			code: EXIT_CODES.GENERAL_ERROR,
+			shouldExit: true,
+			message: "No schema file.",
+		});
+	});
+
+	test("returns parser failures as cli usage errors", async () => {
+		const result = await runCli(["node", "miyagi", "unknown"]);
+
+		expect(result.success).toBe(false);
+		expect(result.code).toBe(EXIT_CODES.CLI_USAGE_ERROR);
+		expect(result.shouldExit).toBe(true);
+	});
+
+	test("logs a doctor hint for config errors outside doctor", async () => {
+		mockGetConfig.mockResolvedValue({
+			components: {
+				folder: null,
+			},
+			docs: {
+				folder: null,
+			},
+			files: {
+				mocks: {
+					name: "mocks",
+					extension: ["json"],
+				},
+				schema: {
+					name: "schema",
+					extension: "json",
+				},
+			},
+		});
+
+		const result = await runCli(["node", "miyagi", "start"]);
+
+		expect(result.code).toBe(EXIT_CODES.CONFIG_ERROR);
+		expect(mockLog).toHaveBeenCalledWith(
+			"info",
+			"Run `miyagi doctor` for a setup check.",
+		);
+	});
+
+	test("does not double-log MiyagiError instances already marked logged", async () => {
+		mockDoctor.mockRejectedValue(
+			new MiyagiError("Already logged.", {
+				code: EXIT_CODES.CONFIG_ERROR,
+				logged: true,
+			}),
+		);
+
+		const result = await runCli(["node", "miyagi", "doctor"]);
+
+		expect(result).toStrictEqual({
+			success: false,
+			code: EXIT_CODES.CONFIG_ERROR,
+			shouldExit: true,
+			message: "Already logged.",
+		});
+		expect(mockLog).not.toHaveBeenCalledWith("error", "Already logged.");
+	});
+
+	test("does not log a doctor hint when already running doctor", async () => {
+		mockDoctor.mockRejectedValue(
+			new MiyagiError("Doctor config issue.", {
+				code: EXIT_CODES.CONFIG_ERROR,
+				logged: true,
+			}),
+		);
+
+		await runCli(["node", "miyagi", "doctor"]);
+
+		expect(mockLog).not.toHaveBeenCalledWith(
+			"info",
+			"Run `miyagi doctor` for a setup check.",
+		);
+	});
+});

--- a/tests/lib/init/args.test.js
+++ b/tests/lib/init/args.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, test, vi } from "vitest";
+import createCli from "../../../lib/init/args.js";
+import { EXIT_CODES } from "../../../lib/errors.js";
+
+describe("createCli", () => {
+	test("passes typed positional args to the new command handler", async () => {
+		const handlers = {
+			start: vi.fn(),
+			build: vi.fn(),
+			new: vi.fn().mockResolvedValue({ success: true, code: 0, shouldExit: true }),
+			mocks: vi.fn(),
+			lint: vi.fn(),
+			drupalAssets: vi.fn(),
+			doctor: vi.fn(),
+		};
+		const { cli, getResult } = createCli(handlers, [
+			"node",
+			"miyagi",
+			"new",
+			"atoms/button",
+			"--only",
+			"tpl",
+			"docs",
+			"--verbose",
+		]);
+
+		await cli.parseAsync();
+
+		expect(handlers.new).toHaveBeenCalledWith(
+			expect.objectContaining({
+				component: "atoms/button",
+				only: ["tpl", "docs"],
+				verbose: true,
+			}),
+		);
+		expect(getResult()).toStrictEqual({
+			success: true,
+			code: 0,
+			shouldExit: true,
+		});
+	});
+
+	test("parses optional component and drupal-assets flags", async () => {
+		const handlers = {
+			start: vi.fn(),
+			build: vi.fn(),
+			new: vi.fn(),
+			mocks: vi.fn(),
+			lint: vi.fn().mockResolvedValue({ success: true, code: 0, shouldExit: true }),
+			drupalAssets: vi
+				.fn()
+				.mockResolvedValue({ success: true, code: 0, shouldExit: true }),
+			doctor: vi.fn(),
+		};
+		const lintCli = createCli(handlers, ["node", "miyagi", "lint"]);
+		await lintCli.cli.parseAsync();
+
+		expect(handlers.lint).toHaveBeenCalledWith(
+			expect.objectContaining({}),
+		);
+
+		const drupalCli = createCli(handlers, [
+			"node",
+			"miyagi",
+			"drupal-assets",
+			"--dry-run",
+			"--ignore-prefixes",
+			"core",
+			"drupal",
+		]);
+		await drupalCli.cli.parseAsync();
+
+		expect(handlers.drupalAssets).toHaveBeenCalledWith(
+			expect.objectContaining({
+				dryRun: true,
+				ignorePrefixes: ["core", "drupal"],
+			}),
+		);
+	});
+
+	test("returns cli usage errors for invalid commands", async () => {
+		const handlers = {
+			start: vi.fn(),
+			build: vi.fn(),
+			new: vi.fn(),
+			mocks: vi.fn(),
+			lint: vi.fn(),
+			drupalAssets: vi.fn(),
+			doctor: vi.fn(),
+		};
+		const { cli } = createCli(handlers, ["node", "miyagi", "wat"]);
+
+		try {
+			await cli.parseAsync();
+		} catch (error) {
+			expect(error).toMatchObject({
+				code: EXIT_CODES.CLI_USAGE_ERROR,
+			});
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Improve Miyagi CLI DX by fixing stale docs, moving command handling to explicit yargs runners, adding `miyagi doctor`, and making CLI exit behavior clearer for setup/debugging and automation.

## What changed

**CLI architecture:**

- Reworked CLI command dispatch around explicit yargs handlers and typed positionals.
- Moved process-exit ownership to `bin/miyagi.js`.
- Added structured CLI results and named exit codes.
- Added centralized config-error guidance to suggest `miyagi doctor`.

**New CLI functionality:**

- Added `miyagi doctor` to check:
  - Node version
  - config presence / parseability
  - `engine.render`
  - `components.folder` / `docs.folder`
  - configured folder existence

**Docs and discoverability:**

- Updated install docs and README to match current package name and Node requirement.
- Added a real CLI command index.
- Added first-run quickstart and common error guidance.
- Documented `doctor` and `drupal-assets`.
- Surfaced useful flags like help, verbose, and watch-report options.

**Tests:**

- Added CLI parser tests.
- Added CLI runner tests.
- Added doctor tests.
- Added bin help smoke test.

## Testing

- `pnpm lint`
- `pnpm test`
- `pnpm vitest run tests/lib/init/args.test.js tests/lib/cli/run.test.js tests/lib/cli/doctor.test.js tests/bin/miyagi.test.js`