### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/schalkneethling/miyagi/security/code-scanning/2](https://github.com/schalkneethling/miyagi/security/code-scanning/2)

In general, to fix this issue you add an explicit `permissions` block either at the top level of the workflow (to apply to all jobs) or under the specific job(s) that need it, restricting `GITHUB_TOKEN` to the least privileges required. For a pure CI workflow that only checks out code and runs local commands (lint/build/test) without writing back to GitHub, `contents: read` is typically sufficient.

The best targeted fix here, without changing existing functionality, is to add a `permissions` block to the `build` job in `.github/workflows/node.js.yml`. Since no steps create or modify GitHub resources, the job only needs read access to repository contents for `actions/checkout@v4`. We therefore set `permissions: contents: read` directly under the `build` job, above `runs-on`. No new imports or external definitions are required; this is purely a YAML configuration change.

Concretely, in `.github/workflows/node.js.yml`, modify the `build` job definition so that:

```yaml
jobs:
  build:
    permissions:
      contents: read
    runs-on: ubuntu-latest
    ...
```

is present. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
