### PR TITLE
fix: watcher startup noise, CSS/JS reload defaults, and router crash

### DIFF
--- a/.cursor/agents/technical-devils-advocate.md
+++ b/.cursor/agents/technical-devils-advocate.md
@@ -1,0 +1,33 @@
+---
+name: technical-devils-advocate
+model: claude-4.6-opus-high-thinking
+description: Technical devil's advocate that challenges feature plans, strategies, and implementation approaches. Use proactively when planning features, designing systems, or proposing solutions. ALWAYS use for plan mode - asks probing questions to uncover risks, edge cases, and alternative approaches before implementation begins.
+---
+
+You are a technical devil's advocate. Your job is to challenge assumptions and stress-test plans before any implementation.
+
+When invoked:
+
+1. Receive the feature plan, system design, or proposed solution
+2. Identify assumptions and unstated constraints
+3. Ask probing questions that expose weaknesses
+4. Surface risks, edge cases, and failure modes
+5. Suggest alternative approaches and tradeoffs
+
+Challenge areas:
+
+- **Risks**: What could fail? Failure modes? Blast radius?
+- **Edge cases**: Boundary conditions, empty states, error paths, race conditions
+- **Alternatives**: Why this approach vs others? What did we reject and why?
+- **Dependencies**: What breaks if X changes? External assumptions?
+- **Scale**: How does this behave at 10x, 100x? Latency, memory, throughput
+- **Operability**: Monitoring, debugging, rollback, incident response
+
+Output format:
+
+- Prioritized list of concerns (critical → minor)
+- Specific probing questions the team should answer
+- Alternative approaches worth considering
+- Recommendations: proceed, pivot, or pause
+
+Be constructive: challenge to improve the plan, not to block it. Every question should help the team make a better decision.

--- a/docs/configuration/default-configuration.md
+++ b/docs/configuration/default-configuration.md
@@ -6,94 +6,94 @@ Please refer to the [available options](/configuration/options/) for a full expl
 import AJV from "ajv";
 
 export default {
-	assets: {
-		root: "",
-		css: [],
-		shared: {
-			css: [],
-			js: [],
-		},
-		isolateComponents: false,
-		customProperties: {
-			files: [],
-			prefixes: {
-				typo: "typo",
-				color: "color",
-				spacing: "spacing",
-			},
-		},
-		folder: [],
-		js: [],
-		manifest: null,
-	},
-	build: {
-		basePath: "/",
-		folder: "build",
-	},
-	docs: {
-		folder: "docs",
-	},
-	components: {
-		folder: "src",
-		ignores: [
-			"node_modules",
-			".git",
-			"package.json",
-			"package-lock.json",
-			".miyagi.js",
-			".miyagi.mjs",
-		],
-		lang: "en",
-		textDirection: "ltr",
-	},
-	engine: {
-		render: null,
-	},
-	extensions: [],
-	files: {
-		css: {
-			name: "index",
-			extension: "css",
-		},
-		js: {
-			name: "index",
-			extension: "js",
-		},
-		mocks: {
-			name: "mocks",
-			extension: ["json", "js"],
-		},
-		schema: {
-			name: "schema",
-			extension: "json",
-		},
-		templates: {
-			name: "index",
-		},
-	},
-	namespaces: {},
-	projectName: "miyagi",
-	ui: {
-		mode: "light",
-		lang: "en",
-		reload: true,
-		reloadAfterChanges: {
-			componentAssets: false,
-		},
-		textDirection: "ltr",
-		theme: {
-			css: null,
-			favicon: null,
-			js: null,
-			logo: {
-				light: null,
-				dark: null,
-			},
-		},
-	},
-	schema: {
-		ajv: AJV,
-		options: {},
-	},
+  assets: {
+    root: "",
+    css: [],
+    shared: {
+      css: [],
+      js: [],
+    },
+    isolateComponents: false,
+    customProperties: {
+      files: [],
+      prefixes: {
+        typo: "typo",
+        color: "color",
+        spacing: "spacing",
+      },
+    },
+    folder: [],
+    js: [],
+    manifest: null,
+  },
+  build: {
+    basePath: "/",
+    folder: "build",
+  },
+  docs: {
+    folder: "docs",
+  },
+  components: {
+    folder: "src",
+    ignores: [
+      "node_modules",
+      ".git",
+      "package.json",
+      "package-lock.json",
+      ".miyagi.js",
+      ".miyagi.mjs",
+    ],
+    lang: "en",
+    textDirection: "ltr",
+  },
+  engine: {
+    render: null,
+  },
+  extensions: [],
+  files: {
+    css: {
+      name: "index",
+      extension: "css",
+    },
+    js: {
+      name: "index",
+      extension: "js",
+    },
+    mocks: {
+      name: "mocks",
+      extension: ["json", "js"],
+    },
+    schema: {
+      name: "schema",
+      extension: "json",
+    },
+    templates: {
+      name: "index",
+    },
+  },
+  namespaces: {},
+  projectName: "miyagi",
+  ui: {
+    mode: "light",
+    lang: "en",
+    reload: true,
+    reloadAfterChanges: {
+      componentAssets: true,
+    },
+    textDirection: "ltr",
+    theme: {
+      css: null,
+      favicon: null,
+      js: null,
+      logo: {
+        light: null,
+        dark: null,
+      },
+    },
+  },
+  schema: {
+    ajv: AJV,
+    options: {},
+  },
 };
 ```

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -358,12 +358,12 @@ Defines if your component automatically reloads after saving.
 
 #### `componentAssets`
 
-default: `false`<br>
+default: `true`<br>
 type: `boolean`
 
 Defines if your component automatically reloads after the css or js file of your component has been updated.
 
-_**NOTE:** This is disabled by default for the case that you have a build process that bundles your components assets. These bundled files could be added to your configuration in the [`assets key`](#assets)._
+_**NOTE:** This is a legacy option. Prefer using [`watch.reload.rules`](#rules) for fine-grained control over reload behavior._
 
 ### `textDirection`
 
@@ -486,6 +486,15 @@ Additional ignore globs. Legacy `components.ignores` values are merged here.
 
 ### `behavior`
 
+#### `startupGraceMs`
+
+default: `500`<br>
+type: `number`
+
+Grace period (in milliseconds) after the file watcher starts during which all events are silently dropped. This prevents spurious state updates caused by parallel build processes (e.g. esbuild, webpack) writing output files to watched directories during server startup.
+
+Set to `0` to disable.
+
 #### `debounceMs`
 
 default: `60`<br>
@@ -533,9 +542,9 @@ default:
   "data": "parent",
   "docs": "parent",
   "schema": "iframe",
-  "componentAsset": "none",
-  "globalCss": "none",
-  "globalJs": "none",
+  "componentAsset": "iframe",
+  "globalCss": "iframe",
+  "globalJs": "iframe",
   "unknown": "parent"
 }
 ```
@@ -556,15 +565,15 @@ Rules:
 - `data`: mock data changes (often affects menu/variation state, so default `parent`)
 - `docs`: markdown docs changes (default `parent`)
 - `schema`: schema file changes (default `iframe`)
-- `componentAsset`: component-local CSS/JS changes (default `none`, useful if assets are bundled elsewhere)
+- `componentAsset`: component-local CSS/JS changes (default `iframe`)
 - `globalCss`: global CSS asset changes
 - `globalJs`: global JS asset changes
 - `unknown`: fallback for unclassified changes
 
 You can set any rule to `none`, `iframe`, or `parent` depending on your project workflow. Typical examples:
 
-- Bundled asset pipeline: keep `componentAsset`, `globalCss`, `globalJs` as `none`
-- Direct file serving during development: set one or more of those to `iframe`
+- Bundled asset pipeline where miyagi should not reload on build output: set `componentAsset`, `globalCss`, `globalJs` to `none`
+- Direct file serving during development: keep defaults (`iframe`)
 - If state/menu consistency is more important than speed: prefer `parent`
 
 ### `socket`

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -1,173 +1,174 @@
 import AJV from "ajv";
 
 export default {
-	defaultUserConfig: {
-		assets: {
-			root: "",
-			css: [],
-			shared: {
-				css: [],
-				js: [],
-			},
-			isolateComponents: false,
-			customProperties: {
-				files: [],
-				prefixes: {
-					typo: "typo",
-					color: "color",
-					spacing: "spacing",
-				},
-			},
-			folder: [],
-			js: [],
-			manifest: null,
-		},
-		build: {
-			basePath: "/",
-			folder: "build",
-		},
-		docs: {
-			folder: "docs",
-		},
-		components: {
-			folder: "src",
-			ignores: [
-				"node_modules",
-				".git",
-				"package.json",
-				"package-lock.json",
-				".miyagi.js",
-				".miyagi.mjs",
-			],
-			lang: "en",
-			textDirection: "ltr",
-		},
-		engine: {
-			render: null,
-			options: {},
-		},
-		lint: {
-			logLevel: "error",
-		},
-		extensions: [],
-		files: {
-			css: {
-				abbr: "css",
-				name: "index",
-				extension: "css",
-			},
-			js: {
-				abbr: "js",
-				name: "index",
-				extension: "js",
-			},
-			mocks: {
-				abbr: "mocks",
-				name: "mocks",
-				extension: ["json", "js"],
-			},
-			schema: {
-				abbr: "schema",
-				name: "schema",
-				extension: "json",
-			},
-			templates: {
-				abbr: "tpl",
-				name: "index",
-			},
-		},
-		namespaces: {},
-		projectName: "miyagi",
-		ui: {
-			mode: "light",
-			lang: "en",
-			reload: true,
-			reloadAfterChanges: {
-				componentAssets: false,
-			},
-			textDirection: "ltr",
-			theme: {
-				css: null,
-				favicon: null,
-				js: null,
-				logo: {
-					light: null,
-					dark: null,
-				},
-			},
-			watchConfigFile: true,
-		},
-		watch: {
-			enabled: true,
-			backend: "chokidar",
-			sources: [],
-			ignore: {
-				defaults: true,
-				patterns: [],
-			},
-			behavior: {
-				debounceMs: 60,
-				coalesceWindowMs: 120,
-				awaitWriteFinish: {
-					enabled: true,
-					stabilityThresholdMs: 200,
-					pollIntervalMs: 50,
-				},
-			},
-			reload: {
-				enabled: true,
-				rules: {
-					template: "iframe",
-					data: "parent",
-					docs: "parent",
-					schema: "iframe",
-					componentAsset: "none",
-					globalCss: "none",
-					globalJs: "none",
-					unknown: "parent",
-				},
-			},
-			socket: {
-				reconnect: {
-					enabled: true,
-					initialDelayMs: 250,
-					maxDelayMs: 5000,
-					jitter: true,
-				},
-				heartbeat: {
-					enabled: true,
-					intervalMs: 30000,
-				},
-			},
-			report: {
-				enabled: true,
-				onStart: true,
-				format: "summary",
-				destination: "stdout",
-				useColors: true,
-			},
-			configFile: {
-				enabled: true,
-			},
-			debug: {
-				logEvents: false,
-				logDecisions: false,
-				logResolvedSources: false,
-			},
-		},
-		schema: {
-			ajv: AJV,
-			verbose: false,
-		},
-		schemaValidationMode: "collect-all",
-	},
-	projectName: "miyagi",
-	defaultPort: 5000,
-	folders: {
-		assets: {
-			development: "frontend/assets",
-			production: "dist",
-		},
-	},
-	defaultVariationName: "default",
+  defaultUserConfig: {
+    assets: {
+      root: "",
+      css: [],
+      shared: {
+        css: [],
+        js: [],
+      },
+      isolateComponents: false,
+      customProperties: {
+        files: [],
+        prefixes: {
+          typo: "typo",
+          color: "color",
+          spacing: "spacing",
+        },
+      },
+      folder: [],
+      js: [],
+      manifest: null,
+    },
+    build: {
+      basePath: "/",
+      folder: "build",
+    },
+    docs: {
+      folder: "docs",
+    },
+    components: {
+      folder: "src",
+      ignores: [
+        "node_modules",
+        ".git",
+        "package.json",
+        "package-lock.json",
+        ".miyagi.js",
+        ".miyagi.mjs",
+      ],
+      lang: "en",
+      textDirection: "ltr",
+    },
+    engine: {
+      render: null,
+      options: {},
+    },
+    lint: {
+      logLevel: "error",
+    },
+    extensions: [],
+    files: {
+      css: {
+        abbr: "css",
+        name: "index",
+        extension: "css",
+      },
+      js: {
+        abbr: "js",
+        name: "index",
+        extension: "js",
+      },
+      mocks: {
+        abbr: "mocks",
+        name: "mocks",
+        extension: ["json", "js"],
+      },
+      schema: {
+        abbr: "schema",
+        name: "schema",
+        extension: "json",
+      },
+      templates: {
+        abbr: "tpl",
+        name: "index",
+      },
+    },
+    namespaces: {},
+    projectName: "miyagi",
+    ui: {
+      mode: "light",
+      lang: "en",
+      reload: true,
+      reloadAfterChanges: {
+        componentAssets: true,
+      },
+      textDirection: "ltr",
+      theme: {
+        css: null,
+        favicon: null,
+        js: null,
+        logo: {
+          light: null,
+          dark: null,
+        },
+      },
+      watchConfigFile: true,
+    },
+    watch: {
+      enabled: true,
+      backend: "chokidar",
+      sources: [],
+      ignore: {
+        defaults: true,
+        patterns: [],
+      },
+      behavior: {
+        startupGraceMs: 500,
+        debounceMs: 60,
+        coalesceWindowMs: 120,
+        awaitWriteFinish: {
+          enabled: true,
+          stabilityThresholdMs: 200,
+          pollIntervalMs: 50,
+        },
+      },
+      reload: {
+        enabled: true,
+        rules: {
+          template: "iframe",
+          data: "parent",
+          docs: "parent",
+          schema: "iframe",
+          componentAsset: "iframe",
+          globalCss: "iframe",
+          globalJs: "iframe",
+          unknown: "parent",
+        },
+      },
+      socket: {
+        reconnect: {
+          enabled: true,
+          initialDelayMs: 250,
+          maxDelayMs: 5000,
+          jitter: true,
+        },
+        heartbeat: {
+          enabled: true,
+          intervalMs: 30000,
+        },
+      },
+      report: {
+        enabled: true,
+        onStart: true,
+        format: "summary",
+        destination: "stdout",
+        useColors: true,
+      },
+      configFile: {
+        enabled: true,
+      },
+      debug: {
+        logEvents: false,
+        logDecisions: false,
+        logResolvedSources: false,
+      },
+    },
+    schema: {
+      ajv: AJV,
+      verbose: false,
+    },
+    schemaValidationMode: "collect-all",
+  },
+  projectName: "miyagi",
+  defaultPort: 5000,
+  folders: {
+    assets: {
+      development: "frontend/assets",
+      production: "dist",
+    },
+  },
+  defaultVariationName: "default",
 };

--- a/lib/init/router.js
+++ b/lib/init/router.js
@@ -14,17 +14,17 @@ import log from "../logger.js";
  * @returns {object} the mock data of the given component
  */
 function getDataForComponent(component) {
-	const { fileContents } = global.state;
-	const { name, extension } = global.config.files.mocks;
+  const { fileContents } = global.state;
+  const { name, extension } = global.config.files.mocks;
 
-	const defaultPath = path.join(
-		component.paths.dir.full,
-		`${name}.${extension[0]}`,
-	);
+  const defaultPath = path.join(
+    component.paths.dir.full,
+    `${name}.${extension[0]}`,
+  );
 
-	const jsPath = path.join(component.paths.dir.full, `${name}.${extension[1]}`);
+  const jsPath = path.join(component.paths.dir.full, `${name}.${extension[1]}`);
 
-	return fileContents[defaultPath] || fileContents[jsPath];
+  return fileContents[defaultPath] || fileContents[jsPath];
 }
 
 /**
@@ -33,7 +33,7 @@ function getDataForComponent(component) {
  * @returns {boolean} is true of the requested variation is in the given mock data
  */
 function checkIfDataIncludesVariation(data, variation) {
-	return data?.$variants?.find((variant) => variant.$name === variation);
+  return data?.$variants?.find((variant) => variant.$name === variation);
 }
 
 /**
@@ -42,209 +42,209 @@ function checkIfDataIncludesVariation(data, variation) {
  * @returns {boolean} is true if the requested variation exists in the mock data of the given component
  */
 function checkIfRequestedVariationIsValid(component, variation) {
-	const data = getDataForComponent(component);
+  const data = getDataForComponent(component);
 
-	if (
-		data &&
-		(variation === data.$name || variation === config.defaultVariationName) &&
-		!data.$hidden
-	) {
-		return true;
-	}
+  if (
+    data &&
+    (variation === data.$name || variation === config.defaultVariationName) &&
+    !data.$hidden
+  ) {
+    return true;
+  }
 
-	if (!data && variation === config.defaultVariationName) {
-		return true;
-	}
+  if (!data && variation === config.defaultVariationName) {
+    return true;
+  }
 
-	return checkIfDataIncludesVariation(data, variation);
+  return checkIfDataIncludesVariation(data, variation);
 }
 
 /**
  * @returns {void}
  */
 export default function Router() {
-	global.app.get("/design-tokens/colors", async (req, res) => {
-		return render.renderMainDesignTokens({
-			res,
-			cookies: req.cookies,
-			type: "colors",
-		});
-	});
+  global.app.get("/design-tokens/colors", async (req, res) => {
+    return render.renderMainDesignTokens({
+      res,
+      cookies: req.cookies,
+      type: "colors",
+    });
+  });
 
-	global.app.get("/iframe/design-tokens/colors", async (req, res) => {
-		return render.iframe.designTokens.colors({ res, cookies: req.cookies });
-	});
+  global.app.get("/iframe/design-tokens/colors", async (req, res) => {
+    return render.iframe.designTokens.colors({ res, cookies: req.cookies });
+  });
 
-	global.app.get("/design-tokens/sizes", async (req, res) => {
-		return render.renderMainDesignTokens({
-			res,
-			cookies: req.cookies,
-			type: "sizes",
-		});
-	});
+  global.app.get("/design-tokens/sizes", async (req, res) => {
+    return render.renderMainDesignTokens({
+      res,
+      cookies: req.cookies,
+      type: "sizes",
+    });
+  });
 
-	global.app.get("/iframe/design-tokens/sizes", async (req, res) => {
-		return render.iframe.designTokens.sizes({ res, cookies: req.cookies });
-	});
+  global.app.get("/iframe/design-tokens/sizes", async (req, res) => {
+    return render.iframe.designTokens.sizes({ res, cookies: req.cookies });
+  });
 
-	global.app.get("/design-tokens/typography", async (req, res) => {
-		return render.renderMainDesignTokens({
-			res,
-			cookies: req.cookies,
-			type: "typography",
-		});
-	});
+  global.app.get("/design-tokens/typography", async (req, res) => {
+    return render.renderMainDesignTokens({
+      res,
+      cookies: req.cookies,
+      type: "typography",
+    });
+  });
 
-	global.app.get("/iframe/design-tokens/typography", async (req, res) => {
-		return render.iframe.designTokens.typography({
-			res,
-			cookies: req.cookies,
-		});
-	});
+  global.app.get("/iframe/design-tokens/typography", async (req, res) => {
+    return render.iframe.designTokens.typography({
+      res,
+      cookies: req.cookies,
+    });
+  });
 
-	global.app.get("/show", async (req, res) => {
-		const { file, variation } = req.query;
+  global.app.get("/show", async (req, res) => {
+    const { file, variation } = req.query;
 
-		if (!file) {
-			return res.redirect(302, "/");
-		}
+    if (!file) {
+      return res.redirect(302, "/");
+    }
 
-		if (file === "all") {
-			return await render.renderMainIndex({ res, cookies: req.cookies });
-		}
+    if (file === "all") {
+      return await render.renderMainIndex({ res, cookies: req.cookies });
+    }
 
-		const routesEntry = global.state.routes.find(
-			(route) => route.paths.dir.short === file,
-		);
+    const routesEntry = global.state.routes.find(
+      (route) => route.paths.dir.short === file,
+    );
 
-		if (!routesEntry) {
-			return res.redirect(302, "/");
-		}
+    if (!routesEntry) {
+      return res.redirect(302, "/");
+    }
 
-		switch (routesEntry.type) {
-			case "components": {
-				if (!routesEntry.paths.tpl) {
-					return await render.renderMainComponentDocs({
-						res,
-						component: routesEntry,
-						cookies: req.cookies,
-					});
-				}
+    switch (routesEntry.type) {
+      case "components": {
+        if (!routesEntry.paths.tpl) {
+          return await render.renderMainComponentDocs({
+            res,
+            component: routesEntry,
+            cookies: req.cookies,
+          });
+        }
 
-				return await render.renderMainComponent(
-					checkIfRequestedVariationIsValid(routesEntry, variation)
-						? {
-								res,
-								component: routesEntry,
-								cookies: req.cookies,
-								variation,
-							}
-						: {
-								res,
-								component: routesEntry,
-								cookies: req.cookies,
-							},
-				);
-			}
+        return await render.renderMainComponent(
+          checkIfRequestedVariationIsValid(routesEntry, variation)
+            ? {
+                res,
+                component: routesEntry,
+                cookies: req.cookies,
+                variation,
+              }
+            : {
+                res,
+                component: routesEntry,
+                cookies: req.cookies,
+              },
+        );
+      }
 
-			case "docs": {
-				return await render.renderMainDocs({
-					res,
-					doc: routesEntry,
-					cookies: req.cookies,
-				});
-			}
+      case "docs": {
+        return await render.renderMainDocs({
+          res,
+          doc: routesEntry,
+          cookies: req.cookies,
+        });
+      }
 
-			default:
-				return res.redirect(302, "/");
-		}
-	});
+      default:
+        return res.redirect(302, "/");
+    }
+  });
 
-	global.app.get("/component", async (req, res) => {
-		const { file, variation, embedded } = req.query;
+  global.app.get("/component", async (req, res) => {
+    const { file, variation, embedded } = req.query;
 
-		if (!file) {
-			return res.redirect(302, global.config.indexPath.default);
-		}
+    if (!file) {
+      return res.redirect(302, global.config.indexPath.default);
+    }
 
-		if (file === "all") {
-			return await render.renderIframeIndex({ res, cookies: req.cookies });
-		}
+    if (file === "all") {
+      return await render.renderIframeIndex({ res, cookies: req.cookies });
+    }
 
-		const routesEntry = global.state.routes.find(
-			(route) => route.paths.dir.short === file,
-		);
+    const routesEntry = global.state.routes.find(
+      (route) => route.paths.dir.short === file,
+    );
 
-		if (!routesEntry) {
-			res.redirect(302, global.config.indexPath.default);
-		}
+    if (!routesEntry) {
+      return res.redirect(302, global.config.indexPath.default);
+    }
 
-		switch (routesEntry.type) {
-			case "components": {
-				if (!routesEntry.paths.tpl) {
-					return await render.renderIframeComponentDocs({
-						res,
-						component: routesEntry,
-						cookies: req.cookies,
-					});
-				}
+    switch (routesEntry.type) {
+      case "components": {
+        if (!routesEntry.paths.tpl) {
+          return await render.renderIframeComponentDocs({
+            res,
+            component: routesEntry,
+            cookies: req.cookies,
+          });
+        }
 
-				if (
-					!variation ||
-					!checkIfRequestedVariationIsValid(routesEntry, variation)
-				) {
-					return await render.renderIframeComponent({
-						res,
-						component: routesEntry,
-						cookies: req.cookies,
-					});
-				}
+        if (
+          !variation ||
+          !checkIfRequestedVariationIsValid(routesEntry, variation)
+        ) {
+          return await render.renderIframeComponent({
+            res,
+            component: routesEntry,
+            cookies: req.cookies,
+          });
+        }
 
-				const data = await getVariationData(routesEntry, decodeURI(variation));
+        const data = await getVariationData(routesEntry, decodeURI(variation));
 
-				if (embedded) {
-					return await render.renderIframeVariation({
-						res,
-						component: routesEntry,
-						variation,
-						cookies: req.cookies,
-						data,
-					});
-				}
+        if (embedded) {
+          return await render.renderIframeVariation({
+            res,
+            component: routesEntry,
+            variation,
+            cookies: req.cookies,
+            data,
+          });
+        }
 
-				if (data?.messages?.length) {
-					for (const { type, text, verbose } of data.messages) {
-						log(type, text, verbose);
-					}
-				}
+        if (data?.messages?.length) {
+          for (const { type, text, verbose } of data.messages) {
+            log(type, text, verbose);
+          }
+        }
 
-				return await render.renderIframeVariationStandalone({
-					res,
-					component: routesEntry,
-					componentData: data?.resolved ?? {},
-					componentDeclaredAssets: data?.$assets || null,
-					cookies: req.cookies,
-				});
-			}
+        return await render.renderIframeVariationStandalone({
+          res,
+          component: routesEntry,
+          componentData: data?.resolved ?? {},
+          componentDeclaredAssets: data?.$assets || null,
+          cookies: req.cookies,
+        });
+      }
 
-			case "docs": {
-				return await render.renderIframeDocs({
-					res,
-					doc: routesEntry,
-					cookies: req.cookies,
-				});
-			}
+      case "docs": {
+        return await render.renderIframeDocs({
+          res,
+          doc: routesEntry,
+          cookies: req.cookies,
+        });
+      }
 
-			default:
-				res.redirect(302, global.config.indexPath.default);
-		}
-	});
+      default:
+        res.redirect(302, global.config.indexPath.default);
+    }
+  });
 
-	global.app.get("/", async (req, res) => {
-		await render.renderMainIndex({ res, cookies: req.cookies });
-	});
+  global.app.get("/", async (req, res) => {
+    await render.renderMainIndex({ res, cookies: req.cookies });
+  });
 
-	global.app.all("*splat", async (req, res) => {
-		res.sendStatus(404);
-	});
+  global.app.all("*splat", async (req, res) => {
+    res.sendStatus(404);
+  });
 }

--- a/lib/init/watcher.js
+++ b/lib/init/watcher.js
@@ -22,10 +22,10 @@ import setViews from "./views.js";
 const SOCKET_PATH = "/__miyagi_ws";
 const sockets = new Set();
 const DEFAULT_RELOAD_MESSAGE = {
-	type: "reload",
-	scope: "iframe",
-	reason: "change",
-	paths: [],
+  type: "reload",
+  scope: "iframe",
+  reason: "change",
+  paths: [],
 };
 const RELOAD_SCOPES = new Set(["none", "iframe", "parent"]);
 let restartFileWatcher = null;
@@ -35,22 +35,22 @@ let restartFileWatcher = null;
  * @returns {number}
  */
 function getEventPriority(eventType) {
-	// Higher value = stronger event for the same path during burst coalescing.
-	// Example: if a file emits "change" then "unlink", we keep "unlink".
-	switch (eventType) {
-		case "unlinkDir":
-			return 5;
-		case "unlink":
-			return 4;
-		case "addDir":
-			return 3;
-		case "add":
-			return 2;
-		case "change":
-			return 1;
-		default:
-			return 0;
-	}
+  // Higher value = stronger event for the same path during burst coalescing.
+  // Example: if a file emits "change" then "unlink", we keep "unlink".
+  switch (eventType) {
+    case "unlinkDir":
+      return 5;
+    case "unlink":
+      return 4;
+    case "addDir":
+      return 3;
+    case "add":
+      return 2;
+    case "change":
+      return 1;
+    default:
+      return 0;
+  }
 }
 
 /**
@@ -58,8 +58,8 @@ function getEventPriority(eventType) {
  * @returns {string}
  */
 function normalizeRelativePath(inputPath) {
-	const absolutePath = path.resolve(inputPath);
-	return path.relative(process.cwd(), absolutePath);
+  const absolutePath = path.resolve(inputPath);
+  return path.relative(process.cwd(), absolutePath);
 }
 
 /**
@@ -67,11 +67,11 @@ function normalizeRelativePath(inputPath) {
  * @returns {string}
  */
 function resolveSourcePath(source) {
-	if (path.isAbsolute(source.path)) {
-		return source.path;
-	}
+  if (path.isAbsolute(source.path)) {
+    return source.path;
+  }
 
-	return path.resolve(process.cwd(), source.path);
+  return path.resolve(process.cwd(), source.path);
 }
 
 /**
@@ -79,27 +79,28 @@ function resolveSourcePath(source) {
  * @param {object} [payload]
  */
 function sendReload(scope, payload = {}) {
-	const normalizedScope = RELOAD_SCOPES.has(scope) ? scope : "parent";
-	const reloadEnabled = global.config.watch?.reload?.enabled ?? global.config.ui.reload;
+  const normalizedScope = RELOAD_SCOPES.has(scope) ? scope : "parent";
+  const reloadEnabled =
+    global.config.watch?.reload?.enabled ?? global.config.ui.reload;
 
-	if (!reloadEnabled || normalizedScope === "none") {
-		return;
-	}
+  if (!reloadEnabled || normalizedScope === "none") {
+    return;
+  }
 
-	const message = JSON.stringify({
-		...DEFAULT_RELOAD_MESSAGE,
-		...payload,
-		scope: normalizedScope,
-	});
+  const message = JSON.stringify({
+    ...DEFAULT_RELOAD_MESSAGE,
+    ...payload,
+    scope: normalizedScope,
+  });
 
-	for (const ws of sockets) {
-		if (ws.readyState !== 1) {
-			sockets.delete(ws);
-			continue;
-		}
+  for (const ws of sockets) {
+    if (ws.readyState !== 1) {
+      sockets.delete(ws);
+      continue;
+    }
 
-		ws.send(message);
-	}
+    ws.send(message);
+  }
 }
 
 /**
@@ -109,19 +110,19 @@ function sendReload(scope, payload = {}) {
  * @returns {string}
  */
 function colorize(color, value, useColors) {
-	if (!useColors) {
-		return value;
-	}
+  if (!useColors) {
+    return value;
+  }
 
-	const colors = {
-		cyan: "\x1b[36m",
-		green: "\x1b[32m",
-		yellow: "\x1b[33m",
-		grey: "\x1b[90m",
-		reset: "\x1b[0m",
-	};
+  const colors = {
+    cyan: "\x1b[36m",
+    green: "\x1b[32m",
+    yellow: "\x1b[33m",
+    grey: "\x1b[90m",
+    reset: "\x1b[0m",
+  };
 
-	return `${colors[color] || ""}${value}${colors.reset}`;
+  return `${colors[color] || ""}${value}${colors.reset}`;
 }
 
 /**
@@ -129,65 +130,67 @@ function colorize(color, value, useColors) {
  * @param {object} watchConfig
  */
 function printWatchReport(report, watchConfig) {
-	const reportConfig = watchConfig?.report || {};
-	if (!reportConfig.enabled || !reportConfig.onStart) {
-		return;
-	}
+  const reportConfig = watchConfig?.report || {};
+  if (!reportConfig.enabled || !reportConfig.onStart) {
+    return;
+  }
 
-	if (reportConfig.format === "json") {
-		console.info(JSON.stringify(report));
-		return;
-	}
+  if (reportConfig.format === "json") {
+    console.info(JSON.stringify(report));
+    return;
+  }
 
-	const useColors = reportConfig.useColors && process.stdout.isTTY;
+  const useColors = reportConfig.useColors && process.stdout.isTTY;
 
-	if (reportConfig.format === "summary") {
-		console.info(
-			`${colorize("cyan", "Watch report:", useColors)} backend=${report.backend
-			} sources=${report.meta.sourceCount} ignores=${report.meta.ignoreCount}`,
-		);
-		return;
-	}
+  if (reportConfig.format === "summary") {
+    console.info(
+      `${colorize("cyan", "Watch report:", useColors)} backend=${
+        report.backend
+      } sources=${report.meta.sourceCount} ignores=${report.meta.ignoreCount}`,
+    );
+    return;
+  }
 
-	console.info(colorize("cyan", "\nWatch report", useColors));
-	console.info(
-		`  ${colorize("grey", "Watcher backend:", useColors)} ${colorize(
-			"green",
-			report.backend,
-			useColors,
-		)}`,
-	);
-	console.info(
-		`  ${colorize("grey", "Diagnostics:", useColors)} sources=${report.meta.sourceCount
-		}, ignores=${report.meta.ignoreCount}`,
-	);
+  console.info(colorize("cyan", "\nWatch report", useColors));
+  console.info(
+    `  ${colorize("grey", "Watcher backend:", useColors)} ${colorize(
+      "green",
+      report.backend,
+      useColors,
+    )}`,
+  );
+  console.info(
+    `  ${colorize("grey", "Diagnostics:", useColors)} sources=${
+      report.meta.sourceCount
+    }, ignores=${report.meta.ignoreCount}`,
+  );
 
-	if (watchConfig?.debug?.logResolvedSources) {
-		console.info(`  ${colorize("grey", "Resolved sources:", useColors)}`);
+  if (watchConfig?.debug?.logResolvedSources) {
+    console.info(`  ${colorize("grey", "Resolved sources:", useColors)}`);
 
-		for (const source of report.sources) {
-			const stateLabel = source.exists ? "exists" : "missing";
-			const stateColor = source.exists ? "green" : "yellow";
-			console.info(
-				`    - ${source.id} (${source.type}) ${source.resolvedPath} [${colorize(
-					stateColor,
-					stateLabel,
-					useColors,
-				)}]`,
-			);
-		}
-	}
+    for (const source of report.sources) {
+      const stateLabel = source.exists ? "exists" : "missing";
+      const stateColor = source.exists ? "green" : "yellow";
+      console.info(
+        `    - ${source.id} (${source.type}) ${source.resolvedPath} [${colorize(
+          stateColor,
+          stateLabel,
+          useColors,
+        )}]`,
+      );
+    }
+  }
 
-	console.info(`  ${colorize("grey", "Ignored patterns:", useColors)}`);
-	for (const pattern of report.ignore.patterns) {
-		console.info(`    - ${pattern}`);
-	}
+  console.info(`  ${colorize("grey", "Ignored patterns:", useColors)}`);
+  for (const pattern of report.ignore.patterns) {
+    console.info(`    - ${pattern}`);
+  }
 
-	console.info(`  ${colorize("grey", "Reload rules:", useColors)}`);
-	for (const [key, scope] of Object.entries(report.reload.rules)) {
-		console.info(`    - ${key}: ${scope}`);
-	}
-	console.info("");
+  console.info(`  ${colorize("grey", "Reload rules:", useColors)}`);
+  for (const [key, scope] of Object.entries(report.reload.rules)) {
+    console.info(`    - ${key}: ${scope}`);
+  }
+  console.info("");
 }
 
 /**
@@ -195,32 +198,32 @@ function printWatchReport(report, watchConfig) {
  * @returns {object[]}
  */
 function getExtensionSources(watchConfig) {
-	const extensionSources = [];
+  const extensionSources = [];
 
-	for (const extension of global.config.extensions) {
-		const ext = Array.isArray(extension) ? extension[0] : extension;
-		const opts =
-			Array.isArray(extension) && extension[1] ? extension[1] : { locales: {} };
+  for (const extension of global.config.extensions) {
+    const ext = Array.isArray(extension) ? extension[0] : extension;
+    const opts =
+      Array.isArray(extension) && extension[1] ? extension[1] : { locales: {} };
 
-		if (!ext.extendWatcher) {
-			continue;
-		}
+    if (!ext.extendWatcher) {
+      continue;
+    }
 
-		const extensionWatch = ext.extendWatcher(opts);
-		if (!extensionWatch?.folder || !extensionWatch?.lang) {
-			continue;
-		}
+    const extensionWatch = ext.extendWatcher(opts);
+    if (!extensionWatch?.folder || !extensionWatch?.lang) {
+      continue;
+    }
 
-		extensionSources.push({
-			id: `extension-${extensionWatch.lang}`,
-			type: "dir",
-			path: path.join(extensionWatch.folder, extensionWatch.lang),
-			recursive: true,
-			optional: true,
-		});
-	}
+    extensionSources.push({
+      id: `extension-${extensionWatch.lang}`,
+      type: "dir",
+      path: path.join(extensionWatch.folder, extensionWatch.lang),
+      recursive: true,
+      optional: true,
+    });
+  }
 
-	return [...(watchConfig.sources || []), ...extensionSources];
+  return [...(watchConfig.sources || []), ...extensionSources];
 }
 
 /**
@@ -228,54 +231,54 @@ function getExtensionSources(watchConfig) {
  * @returns {object}
  */
 function resolveWatchTargets(watchConfig) {
-	const sources = getExtensionSources(watchConfig);
-	const ignorePatterns = [
-		...(watchConfig.ignore?.defaults ? ["node_modules/**", ".git/**"] : []),
-		...(watchConfig.ignore?.patterns || []),
-	];
-	const reportSources = [];
-	const targets = [];
+  const sources = getExtensionSources(watchConfig);
+  const ignorePatterns = [
+    ...(watchConfig.ignore?.defaults ? ["node_modules/**", ".git/**"] : []),
+    ...(watchConfig.ignore?.patterns || []),
+  ];
+  const reportSources = [];
+  const targets = [];
 
-	for (const source of sources) {
-		if (!source || typeof source.path !== "string") continue;
-		const resolvedPath = resolveSourcePath(source);
-		const exists = fs.existsSync(resolvedPath);
+  for (const source of sources) {
+    if (!source || typeof source.path !== "string") continue;
+    const resolvedPath = resolveSourcePath(source);
+    const exists = fs.existsSync(resolvedPath);
 
-		reportSources.push({
-			id: source.id,
-			type: source.type,
-			inputPath: source.path,
-			resolvedPath,
-			exists,
-			recursive: source.recursive !== false,
-			optional: source.optional === true,
-			ignored: anymatch(ignorePatterns, normalizeRelativePath(resolvedPath)),
-		});
+    reportSources.push({
+      id: source.id,
+      type: source.type,
+      inputPath: source.path,
+      resolvedPath,
+      exists,
+      recursive: source.recursive !== false,
+      optional: source.optional === true,
+      ignored: anymatch(ignorePatterns, normalizeRelativePath(resolvedPath)),
+    });
 
-		if (exists) {
-			targets.push(resolvedPath);
-		}
-	}
+    if (exists) {
+      targets.push(resolvedPath);
+    }
+  }
 
-	return {
-		targets: [...new Set(targets)].sort(),
-		ignorePatterns,
-		report: {
-			backend: "chokidar",
-			sources: reportSources.sort((a, b) => a.id.localeCompare(b.id)),
-			ignore: {
-				defaultsEnabled: Boolean(watchConfig.ignore?.defaults),
-				patterns: [...new Set(ignorePatterns)].sort(),
-			},
-			reload: {
-				rules: watchConfig.reload.rules,
-			},
-			meta: {
-				sourceCount: reportSources.length,
-				ignoreCount: [...new Set(ignorePatterns)].length,
-			},
-		},
-	};
+  return {
+    targets: [...new Set(targets)].sort(),
+    ignorePatterns,
+    report: {
+      backend: "chokidar",
+      sources: reportSources.sort((a, b) => a.id.localeCompare(b.id)),
+      ignore: {
+        defaultsEnabled: Boolean(watchConfig.ignore?.defaults),
+        patterns: [...new Set(ignorePatterns)].sort(),
+      },
+      reload: {
+        rules: watchConfig.reload.rules,
+      },
+      meta: {
+        sourceCount: reportSources.length,
+        ignoreCount: [...new Set(ignorePatterns)].length,
+      },
+    },
+  };
 }
 
 /**
@@ -283,39 +286,39 @@ function resolveWatchTargets(watchConfig) {
  * @returns {Promise<object>}
  */
 async function updateFileContents(events) {
-	const data = helpers.cloneDeep(global.state.fileContents);
+  const data = helpers.cloneDeep(global.state.fileContents);
 
-	try {
-		await Promise.all(
-			events.map(async ({ changedPath, relativePath }) => {
-				const fullPath = path.resolve(changedPath);
+  try {
+    await Promise.all(
+      events.map(async ({ changedPath, relativePath }) => {
+        const fullPath = path.resolve(changedPath);
 
-				if (
-					fs.existsSync(fullPath) &&
-					fs.lstatSync(fullPath).isFile() &&
-					(helpers.fileIsTemplateFile(relativePath) ||
-						helpers.fileIsDataFile(relativePath) ||
-						helpers.fileIsDocumentationFile(relativePath) ||
-						helpers.fileIsSchemaFile(relativePath))
-				) {
-					try {
-						const result = await readFile(fullPath);
-						data[fullPath] = result;
-						return Promise.resolve();
-					} catch (err) {
-						return Promise.reject(err.message);
-					}
-				} else {
-					delete data[fullPath];
-					return Promise.resolve();
-				}
-			}),
-		);
+        if (
+          fs.existsSync(fullPath) &&
+          fs.lstatSync(fullPath).isFile() &&
+          (helpers.fileIsTemplateFile(relativePath) ||
+            helpers.fileIsDataFile(relativePath) ||
+            helpers.fileIsDocumentationFile(relativePath) ||
+            helpers.fileIsSchemaFile(relativePath))
+        ) {
+          try {
+            const result = await readFile(fullPath);
+            data[fullPath] = result;
+            return Promise.resolve();
+          } catch (err) {
+            return Promise.reject(err.message);
+          }
+        } else {
+          delete data[fullPath];
+          return Promise.resolve();
+        }
+      }),
+    );
 
-		return data;
-	} catch (err) {
-		log("error", err);
-	}
+    return data;
+  } catch (err) {
+    log("error", err);
+  }
 }
 
 /**
@@ -323,7 +326,7 @@ async function updateFileContents(events) {
  * @returns {boolean}
  */
 function pathExistsAsDirectory(changedPath) {
-	return fs.existsSync(changedPath) && fs.lstatSync(changedPath).isDirectory();
+  return fs.existsSync(changedPath) && fs.lstatSync(changedPath).isDirectory();
 }
 
 /**
@@ -331,248 +334,261 @@ function pathExistsAsDirectory(changedPath) {
  * @returns {Promise<void>}
  */
 async function handleFileChange(events) {
-	for (const extension of global.config.extensions) {
-		const ext = Array.isArray(extension) ? extension[0] : extension;
-		const opts =
-			Array.isArray(extension) && extension[1] ? extension[1] : { locales: {} };
+  for (const extension of global.config.extensions) {
+    const ext = Array.isArray(extension) ? extension[0] : extension;
+    const opts =
+      Array.isArray(extension) && extension[1] ? extension[1] : { locales: {} };
 
-		if (ext.callbacks?.fileChanged) {
-			await ext.callbacks.fileChanged(opts);
-		}
-	}
+    if (ext.callbacks?.fileChanged) {
+      await ext.callbacks.fileChanged(opts);
+    }
+  }
 
-	const watchRules = global.config.watch.reload.rules;
-	const templateEvents = events.filter(({ relativePath }) =>
-		helpers.fileIsTemplateFile(relativePath),
-	);
-	const dataEvents = events.filter(({ relativePath }) =>
-		helpers.fileIsDataFile(relativePath),
-	);
-	const docEvents = events.filter(({ relativePath }) =>
-		helpers.fileIsDocumentationFile(relativePath),
-	);
-	const schemaEvents = events.filter(({ relativePath }) =>
-		helpers.fileIsSchemaFile(relativePath),
-	);
-	const componentAssetEvents = events.filter(({ relativePath }) =>
-		helpers.fileIsAssetFile(relativePath),
-	);
-	const cssEvents = events.filter(({ relativePath }) => relativePath.endsWith(".css"));
-	const jsEvents = events.filter(({ relativePath }) => relativePath.endsWith(".js"));
-	const hasRemoveEvents = events.some(({ eventType }) =>
-		["unlink", "unlinkDir"].includes(eventType),
-	);
-	const hasDirectoryEvents = events.some(
-		({ changedPath, eventType }) =>
-			["addDir", "unlinkDir"].includes(eventType) || pathExistsAsDirectory(changedPath),
-	);
+  const watchRules = global.config.watch.reload.rules;
+  const templateEvents = events.filter(({ relativePath }) =>
+    helpers.fileIsTemplateFile(relativePath),
+  );
+  const dataEvents = events.filter(({ relativePath }) =>
+    helpers.fileIsDataFile(relativePath),
+  );
+  const docEvents = events.filter(({ relativePath }) =>
+    helpers.fileIsDocumentationFile(relativePath),
+  );
+  const schemaEvents = events.filter(({ relativePath }) =>
+    helpers.fileIsSchemaFile(relativePath),
+  );
+  const componentAssetEvents = events.filter(({ relativePath }) =>
+    helpers.fileIsAssetFile(relativePath),
+  );
+  const cssEvents = events.filter(({ relativePath }) =>
+    relativePath.endsWith(".css"),
+  );
+  const jsEvents = events.filter(({ relativePath }) =>
+    relativePath.endsWith(".js"),
+  );
+  const hasRemoveEvents = events.some(({ eventType }) =>
+    ["unlink", "unlinkDir"].includes(eventType),
+  );
+  const hasDirectoryEvents = events.some(
+    ({ changedPath, eventType }) =>
+      ["addDir", "unlinkDir"].includes(eventType) ||
+      pathExistsAsDirectory(changedPath),
+  );
 
-	const configFilePath = global.config.userFileName
-		? path.resolve(process.cwd(), global.config.userFileName)
-		: null;
-	const hasConfigFileEvent =
-		configFilePath &&
-		events.some(({ changedPath }) => path.resolve(changedPath) === configFilePath);
+  const configFilePath = global.config.userFileName
+    ? path.resolve(process.cwd(), global.config.userFileName)
+    : null;
+  const hasConfigFileEvent =
+    configFilePath &&
+    events.some(
+      ({ changedPath }) => path.resolve(changedPath) === configFilePath,
+    );
 
-	if (hasConfigFileEvent && global.config.watch.configFile.enabled) {
-		await configurationFileUpdated();
-		sendReload("parent", {
-			reason: "config",
-			paths: [global.config.userFileName],
-		});
-		return;
-	}
+  if (hasConfigFileEvent && global.config.watch.configFile.enabled) {
+    await configurationFileUpdated();
+    sendReload("parent", {
+      reason: "config",
+      paths: [global.config.userFileName],
+    });
+    return;
+  }
 
-	if (
-		hasDirectoryEvents &&
-		!hasRemoveEvents &&
-		templateEvents.length === 0 &&
-		dataEvents.length === 0 &&
-		docEvents.length === 0 &&
-		schemaEvents.length === 0 &&
-		componentAssetEvents.length === 0 &&
-		cssEvents.length === 0 &&
-		jsEvents.length === 0
-	) {
-		await setState({
-			sourceTree: true,
-			fileContents: true,
-			menu: true,
-			partials: true,
-		});
+  if (
+    hasDirectoryEvents &&
+    !hasRemoveEvents &&
+    templateEvents.length === 0 &&
+    dataEvents.length === 0 &&
+    docEvents.length === 0 &&
+    schemaEvents.length === 0 &&
+    componentAssetEvents.length === 0 &&
+    cssEvents.length === 0 &&
+    jsEvents.length === 0
+  ) {
+    await setState({
+      sourceTree: true,
+      fileContents: true,
+      menu: true,
+      partials: true,
+    });
 
-		sendReload(watchRules.unknown, {
-			reason: "directory",
-			paths: events.map(({ relativePath }) => relativePath),
-		});
-		log("success", `${t("updatingDone")}\n`);
-		return;
-	}
+    sendReload(watchRules.unknown, {
+      reason: "directory",
+      paths: events.map(({ relativePath }) => relativePath),
+    });
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
 
-	if (hasRemoveEvents) {
-		await setState({
-			sourceTree: true,
-			fileContents: await updateFileContents(events),
-			menu: true,
-			partials: true,
-		});
+  if (hasRemoveEvents) {
+    await setState({
+      sourceTree: true,
+      fileContents: await updateFileContents(events),
+      menu: true,
+      partials: true,
+    });
 
-		sendReload("parent", {
-			reason: "remove",
-			paths: events.map(({ relativePath }) => relativePath),
-		});
-		log("success", `${t("updatingDone")}\n`);
-		return;
-	}
+    sendReload("parent", {
+      reason: "remove",
+      paths: events.map(({ relativePath }) => relativePath),
+    });
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
 
-	if (templateEvents.length > 0) {
-		const allTemplatePathsExistAsPartials = templateEvents.every(({ relativePath }) => {
-			const shortPath = relativePath.replace(
-				path.join(global.config.components.folder, "/"),
-				"",
-			);
-			return Object.keys(global.state.partials).includes(shortPath);
-		});
+  if (templateEvents.length > 0) {
+    const allTemplatePathsExistAsPartials = templateEvents.every(
+      ({ relativePath }) => {
+        const shortPath = relativePath.replace(
+          path.join(global.config.components.folder, "/"),
+          "",
+        );
+        return Object.keys(global.state.partials).includes(shortPath);
+      },
+    );
 
-		if (allTemplatePathsExistAsPartials) {
-			await setState({
-				fileContents: await updateFileContents(templateEvents),
-			});
+    if (allTemplatePathsExistAsPartials) {
+      await setState({
+        fileContents: await updateFileContents(templateEvents),
+      });
 
-			sendReload(watchRules.template, {
-				reason: "template",
-				paths: templateEvents.map(({ relativePath }) => relativePath),
-			});
-		} else {
-			await setState({
-				fileContents: await updateFileContents(templateEvents),
-				sourceTree: true,
-				menu: true,
-				partials: true,
-			});
+      sendReload(watchRules.template, {
+        reason: "template",
+        paths: templateEvents.map(({ relativePath }) => relativePath),
+      });
+    } else {
+      await setState({
+        fileContents: await updateFileContents(templateEvents),
+        sourceTree: true,
+        menu: true,
+        partials: true,
+      });
 
-			sendReload("parent", {
-				reason: "template-added",
-				paths: templateEvents.map(({ relativePath }) => relativePath),
-			});
-		}
+      sendReload("parent", {
+        reason: "template-added",
+        paths: templateEvents.map(({ relativePath }) => relativePath),
+      });
+    }
 
-		log("success", `${t("updatingDone")}\n`);
-		return;
-	}
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
 
-	if (dataEvents.length > 0) {
-		const hasBeenAdded = dataEvents.some(
-			({ eventType, changedPath }) =>
-				eventType === "add" ||
-				!Object.keys(global.state.fileContents).includes(path.resolve(changedPath)),
-		);
+  if (dataEvents.length > 0) {
+    const hasBeenAdded = dataEvents.some(
+      ({ eventType, changedPath }) =>
+        eventType === "add" ||
+        !Object.keys(global.state.fileContents).includes(
+          path.resolve(changedPath),
+        ),
+    );
 
-		await setState({
-			fileContents: await updateFileContents(dataEvents),
-			sourceTree: hasBeenAdded,
-			menu: true,
-		});
+    await setState({
+      fileContents: await updateFileContents(dataEvents),
+      sourceTree: hasBeenAdded,
+      menu: true,
+    });
 
-		sendReload(watchRules.data, {
-			reason: hasBeenAdded ? "data-added" : "data",
-			paths: dataEvents.map(({ relativePath }) => relativePath),
-		});
-		log("success", `${t("updatingDone")}\n`);
-		return;
-	}
+    sendReload(watchRules.data, {
+      reason: hasBeenAdded ? "data-added" : "data",
+      paths: dataEvents.map(({ relativePath }) => relativePath),
+    });
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
 
-	if (docEvents.length > 0) {
-		const hasBeenAdded = docEvents.some(
-			({ eventType, changedPath }) =>
-				eventType === "add" ||
-				!Object.keys(global.state.fileContents).includes(path.resolve(changedPath)),
-		);
+  if (docEvents.length > 0) {
+    const hasBeenAdded = docEvents.some(
+      ({ eventType, changedPath }) =>
+        eventType === "add" ||
+        !Object.keys(global.state.fileContents).includes(
+          path.resolve(changedPath),
+        ),
+    );
 
-		await setState({
-			fileContents: await updateFileContents(docEvents),
-			sourceTree: hasBeenAdded,
-			menu: hasBeenAdded,
-		});
+    await setState({
+      fileContents: await updateFileContents(docEvents),
+      sourceTree: hasBeenAdded,
+      menu: hasBeenAdded,
+    });
 
-		sendReload(watchRules.docs, {
-			reason: hasBeenAdded ? "docs-added" : "docs",
-			paths: docEvents.map(({ relativePath }) => relativePath),
-		});
-		log("success", `${t("updatingDone")}\n`);
-		return;
-	}
+    sendReload(watchRules.docs, {
+      reason: hasBeenAdded ? "docs-added" : "docs",
+      paths: docEvents.map(({ relativePath }) => relativePath),
+    });
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
 
-	if (schemaEvents.length > 0) {
-		await setState({
-			fileContents: await updateFileContents(schemaEvents),
-		});
+  if (schemaEvents.length > 0) {
+    await setState({
+      fileContents: await updateFileContents(schemaEvents),
+    });
 
-		sendReload(watchRules.schema, {
-			reason: "schema",
-			paths: schemaEvents.map(({ relativePath }) => relativePath),
-		});
-		log("success", `${t("updatingDone")}\n`);
-		return;
-	}
+    sendReload(watchRules.schema, {
+      reason: "schema",
+      paths: schemaEvents.map(({ relativePath }) => relativePath),
+    });
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
 
-	if (componentAssetEvents.length > 0) {
-		sendReload(watchRules.componentAsset, {
-			reason: "component-asset",
-			paths: componentAssetEvents.map(({ relativePath }) => relativePath),
-		});
-		log("success", `${t("updatingDone")}\n`);
-		return;
-	}
+  if (componentAssetEvents.length > 0) {
+    sendReload(watchRules.componentAsset, {
+      reason: "component-asset",
+      paths: componentAssetEvents.map(({ relativePath }) => relativePath),
+    });
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
 
-	if (cssEvents.length > 0) {
-		if (
-			cssEvents.some(({ relativePath }) =>
-				global.config.assets.customProperties.files.includes(relativePath),
-			)
-		) {
-			await setState({
-				css: true,
-			});
-		} else {
-			await setState({
-				menu: true,
-			});
-		}
+  if (cssEvents.length > 0) {
+    if (
+      cssEvents.some(({ relativePath }) =>
+        global.config.assets.customProperties.files.includes(relativePath),
+      )
+    ) {
+      await setState({
+        css: true,
+      });
+    } else {
+      await setState({
+        menu: true,
+      });
+    }
 
-		sendReload(watchRules.globalCss, {
-			reason: "css",
-			paths: cssEvents.map(({ relativePath }) => relativePath),
-		});
-		log("success", `${t("updatingDone")}\n`);
-		return;
-	}
+    sendReload(watchRules.globalCss, {
+      reason: "css",
+      paths: cssEvents.map(({ relativePath }) => relativePath),
+    });
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
 
-	if (jsEvents.length > 0) {
-		await setState({
-			menu: true,
-		});
+  if (jsEvents.length > 0) {
+    await setState({
+      menu: true,
+    });
 
-		sendReload(watchRules.globalJs, {
-			reason: "js",
-			paths: jsEvents.map(({ relativePath }) => relativePath),
-		});
-		log("success", `${t("updatingDone")}\n`);
-		return;
-	}
+    sendReload(watchRules.globalJs, {
+      reason: "js",
+      paths: jsEvents.map(({ relativePath }) => relativePath),
+    });
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
 
-	await setState({
-		sourceTree: true,
-		fileContents: true,
-		menu: true,
-		partials: true,
-	});
+  await setState({
+    sourceTree: true,
+    fileContents: true,
+    menu: true,
+    partials: true,
+  });
 
-	sendReload(watchRules.unknown, {
-		reason: "unknown",
-		paths: events.map(({ relativePath }) => relativePath),
-	});
-	log("success", `${t("updatingDone")}\n`);
+  sendReload(watchRules.unknown, {
+    reason: "unknown",
+    paths: events.map(({ relativePath }) => relativePath),
+  });
+  log("success", `${t("updatingDone")}\n`);
 }
 
 /**
@@ -580,218 +596,235 @@ async function handleFileChange(events) {
  * @returns {Array<{ eventType: string, changedPath: string, relativePath: string }>}
  */
 function snapshotPendingEvents(pendingByPath) {
-	return [...pendingByPath.values()]
-		// Process highest-priority events first to keep structural changes deterministic.
-		.sort((a, b) => getEventPriority(b.eventType) - getEventPriority(a.eventType))
-		.map((entry) => ({
-			eventType: entry.eventType,
-			changedPath: entry.changedPath,
-			relativePath: normalizeRelativePath(entry.changedPath),
-		}));
+  return (
+    [...pendingByPath.values()]
+      // Process highest-priority events first to keep structural changes deterministic.
+      .sort(
+        (a, b) => getEventPriority(b.eventType) - getEventPriority(a.eventType),
+      )
+      .map((entry) => ({
+        eventType: entry.eventType,
+        changedPath: entry.changedPath,
+        relativePath: normalizeRelativePath(entry.changedPath),
+      }))
+  );
 }
 
 /**
  * @param {object} server
  */
 export default function Watcher(server) {
-	const wss = new WebSocketServer({ noServer: true });
-	let watcher;
-	let debounceTimer = null;
-	let isProcessing = false;
-	const pendingByPath = new Map();
+  const wss = new WebSocketServer({ noServer: true });
+  let watcher;
+  let debounceTimer = null;
+  let isProcessing = false;
+  let watcherStartedAt = null;
+  const pendingByPath = new Map();
 
-	const startHeartbeat = () => {
-		const heartbeatConfig = global.config.watch?.socket?.heartbeat;
-		if (!heartbeatConfig?.enabled) {
-			return null;
-		}
+  const startHeartbeat = () => {
+    const heartbeatConfig = global.config.watch?.socket?.heartbeat;
+    if (!heartbeatConfig?.enabled) {
+      return null;
+    }
 
-		return setInterval(() => {
-			for (const ws of sockets) {
-				if (ws.readyState !== 1) {
-					sockets.delete(ws);
-					continue;
-				}
+    return setInterval(() => {
+      for (const ws of sockets) {
+        if (ws.readyState !== 1) {
+          sockets.delete(ws);
+          continue;
+        }
 
-				ws.ping();
-			}
-		}, heartbeatConfig.intervalMs);
-	};
+        ws.ping();
+      }
+    }, heartbeatConfig.intervalMs);
+  };
 
-	const heartbeatInterval = startHeartbeat();
+  const heartbeatInterval = startHeartbeat();
 
-	const processPendingEvents = async () => {
-		if (isProcessing) {
-			return;
-		}
+  const processPendingEvents = async () => {
+    if (isProcessing) {
+      return;
+    }
 
-		if (pendingByPath.size === 0) {
-			return;
-		}
+    if (pendingByPath.size === 0) {
+      return;
+    }
 
-		isProcessing = true;
-		try {
-			log("info", t("updatingStarted"));
-			const events = snapshotPendingEvents(pendingByPath);
-			pendingByPath.clear();
-			await handleFileChange(events);
-		} catch (error) {
-			log("error", "Error while processing file changes.", error);
-		} finally {
-			isProcessing = false;
-			if (pendingByPath.size > 0) {
-				void processPendingEvents();
-			}
-		}
-	};
+    isProcessing = true;
+    try {
+      log("info", t("updatingStarted"));
+      const events = snapshotPendingEvents(pendingByPath);
+      pendingByPath.clear();
+      await handleFileChange(events);
+    } catch (error) {
+      log("error", "Error while processing file changes.", error);
+    } finally {
+      isProcessing = false;
+      if (pendingByPath.size > 0) {
+        void processPendingEvents();
+      }
+    }
+  };
 
-	const enqueueEvent = (eventType, changedPath) => {
-		const absolutePath = path.resolve(changedPath);
-		const existing = pendingByPath.get(absolutePath);
-		const shouldReplace =
-			!existing ||
-			getEventPriority(eventType) >= getEventPriority(existing.eventType);
+  const enqueueEvent = (eventType, changedPath) => {
+    const graceMs = global.config.watch?.behavior?.startupGraceMs ?? 0;
+    if (
+      watcherStartedAt &&
+      graceMs > 0 &&
+      Date.now() - watcherStartedAt < graceMs
+    ) {
+      return;
+    }
 
-		if (shouldReplace) {
-			// Keep only the strongest event per path inside the coalescing window.
-			pendingByPath.set(absolutePath, {
-				eventType,
-				changedPath: absolutePath,
-			});
-		}
+    const absolutePath = path.resolve(changedPath);
+    const existing = pendingByPath.get(absolutePath);
+    const shouldReplace =
+      !existing ||
+      getEventPriority(eventType) >= getEventPriority(existing.eventType);
 
-		const watchBehavior = global.config.watch?.behavior || {};
-		const delay = Math.max(
-			watchBehavior.debounceMs || 0,
-			watchBehavior.coalesceWindowMs || 0,
-		);
+    if (shouldReplace) {
+      // Keep only the strongest event per path inside the coalescing window.
+      pendingByPath.set(absolutePath, {
+        eventType,
+        changedPath: absolutePath,
+      });
+    }
 
-		if (debounceTimer) {
-			clearTimeout(debounceTimer);
-		}
+    const watchBehavior = global.config.watch?.behavior || {};
+    const delay = Math.max(
+      watchBehavior.debounceMs || 0,
+      watchBehavior.coalesceWindowMs || 0,
+    );
 
-		debounceTimer = setTimeout(() => {
-			debounceTimer = null;
-			void processPendingEvents();
-		}, delay);
-	};
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+    }
 
-	const setupFileWatcher = () => {
-		const watchConfig = global.config.watch || {};
-		if (watchConfig.enabled === false) {
-			return;
-		}
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+      void processPendingEvents();
+    }, delay);
+  };
 
-		if (watcher) {
-			void watcher.close();
-		}
+  const setupFileWatcher = () => {
+    const watchConfig = global.config.watch || {};
+    if (watchConfig.enabled === false) {
+      return;
+    }
 
-		const { targets, ignorePatterns, report } = resolveWatchTargets(watchConfig);
-		const awaitWriteFinish = watchConfig.behavior?.awaitWriteFinish || {};
+    if (watcher) {
+      void watcher.close();
+    }
 
-		printWatchReport(report, watchConfig);
+    const { targets, ignorePatterns, report } =
+      resolveWatchTargets(watchConfig);
+    const awaitWriteFinish = watchConfig.behavior?.awaitWriteFinish || {};
 
-		if (targets.length === 0) {
-			log("error", t("watchingFilesFailed"));
-			return;
-		}
+    printWatchReport(report, watchConfig);
 
-		watcher = chokidar.watch(targets, {
-			ignoreInitial: true,
-			persistent: true,
-			ignored(changedPath) {
-				const relativePath = normalizeRelativePath(changedPath);
-				return anymatch(ignorePatterns, relativePath);
-			},
-			awaitWriteFinish: awaitWriteFinish.enabled
-				? {
-					stabilityThreshold: awaitWriteFinish.stabilityThresholdMs,
-					pollInterval: awaitWriteFinish.pollIntervalMs,
-				}
-				: false,
-		});
+    if (targets.length === 0) {
+      log("error", t("watchingFilesFailed"));
+      return;
+    }
 
-		watcher.on("all", (eventType, changedPath) => {
-			const watchDebug = global.config.watch?.debug || {};
-			if (watchDebug.logEvents) {
-				log("info", `watch:event=${eventType} path=${changedPath}`);
-			}
+    watcher = chokidar.watch(targets, {
+      ignoreInitial: true,
+      persistent: true,
+      ignored(changedPath) {
+        const relativePath = normalizeRelativePath(changedPath);
+        return anymatch(ignorePatterns, relativePath);
+      },
+      awaitWriteFinish: awaitWriteFinish.enabled
+        ? {
+            stabilityThreshold: awaitWriteFinish.stabilityThresholdMs,
+            pollInterval: awaitWriteFinish.pollIntervalMs,
+          }
+        : false,
+    });
 
-			enqueueEvent(eventType, changedPath);
-		});
+    watcher.on("all", (eventType, changedPath) => {
+      const watchDebug = global.config.watch?.debug || {};
+      if (watchDebug.logEvents) {
+        log("info", `watch:event=${eventType} path=${changedPath}`);
+      }
 
-		watcher.on("error", (error) => {
-			log("error", t("watchingFilesFailed"), error);
-		});
-	};
-	restartFileWatcher = setupFileWatcher;
+      enqueueEvent(eventType, changedPath);
+    });
 
-	wss.on("connection", function open(ws) {
-		sockets.add(ws);
+    watcher.on("error", (error) => {
+      log("error", t("watchingFilesFailed"), error);
+    });
 
-		ws.on("close", () => {
-			sockets.delete(ws);
-		});
+    watcherStartedAt = Date.now();
+  };
+  restartFileWatcher = setupFileWatcher;
 
-		ws.on("error", () => {
-			sockets.delete(ws);
-		});
-	});
+  wss.on("connection", function open(ws) {
+    sockets.add(ws);
 
-	server.on("upgrade", (request, socket, head) => {
-		const requestUrl = new URL(
-			request.url || "/",
-			`http://${request.headers.host || "localhost"}`,
-		);
+    ws.on("close", () => {
+      sockets.delete(ws);
+    });
 
-		if (requestUrl.pathname !== SOCKET_PATH) {
-			socket.destroy();
-			return;
-		}
+    ws.on("error", () => {
+      sockets.delete(ws);
+    });
+  });
 
-		wss.handleUpgrade(request, socket, head, (ws) => {
-			wss.emit("connection", ws, request);
-		});
-	});
+  server.on("upgrade", (request, socket, head) => {
+    const requestUrl = new URL(
+      request.url || "/",
+      `http://${request.headers.host || "localhost"}`,
+    );
 
-	setupFileWatcher();
+    if (requestUrl.pathname !== SOCKET_PATH) {
+      socket.destroy();
+      return;
+    }
 
-	server.on("close", () => {
-		if (heartbeatInterval) {
-			clearInterval(heartbeatInterval);
-		}
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      wss.emit("connection", ws, request);
+    });
+  });
 
-		if (watcher) {
-			void watcher.close();
-		}
-	});
+  setupFileWatcher();
+
+  server.on("close", () => {
+    if (heartbeatInterval) {
+      clearInterval(heartbeatInterval);
+    }
+
+    if (watcher) {
+      void watcher.close();
+    }
+  });
 }
 
 /**
  * @returns {Promise<void>}
  */
 async function configurationFileUpdated() {
-	log("info", t("updatingConfiguration"));
+  log("info", t("updatingConfiguration"));
 
-	const config = await getConfig(yargs.argv);
+  const config = await getConfig(yargs.argv);
 
-	if (config) {
-		global.config = config;
-		if (restartFileWatcher) {
-			restartFileWatcher();
-		}
-		await setEngines();
-		await setState({
-			sourceTree: true,
-			fileContents: true,
-			menu: true,
-			partials: true,
-			css: true,
-		});
+  if (config) {
+    global.config = config;
+    if (restartFileWatcher) {
+      restartFileWatcher();
+    }
+    await setEngines();
+    await setState({
+      sourceTree: true,
+      fileContents: true,
+      menu: true,
+      partials: true,
+      css: true,
+    });
 
-		setStatic();
-		setViews();
+    setStatic();
+    setViews();
 
-		log("success", `${t("updatingConfigurationDone")}\n`);
-	}
+    log("success", `${t("updatingConfigurationDone")}\n`);
+  }
 }

--- a/tests/lib/init/watcher.test.js
+++ b/tests/lib/init/watcher.test.js
@@ -4,239 +4,268 @@ import defaultConfig from "../../../lib/default-config.js";
 const chokidarOnHandlers = {};
 const wsServerHandlers = {};
 const watcherInstance = {
-	on: vi.fn((eventName, callback) => {
-		chokidarOnHandlers[eventName] = callback;
-		return watcherInstance;
-	}),
-	close: vi.fn(),
+  on: vi.fn((eventName, callback) => {
+    chokidarOnHandlers[eventName] = callback;
+    return watcherInstance;
+  }),
+  close: vi.fn(),
 };
 const watchMock = vi.fn(() => watcherInstance);
 const mockSetState = vi.fn(async () => {});
 
 vi.mock("chokidar", () => ({
-	default: {
-		watch: watchMock,
-	},
+  default: {
+    watch: watchMock,
+  },
 }));
 
 vi.mock("../../../lib/state/index.js", () => ({
-	default: mockSetState,
+  default: mockSetState,
 }));
 
 vi.mock("../../../lib/config.js", () => ({
-	default: vi.fn(async () => ({})),
+  default: vi.fn(async () => ({})),
 }));
 
 vi.mock("../../../lib/state/file-contents.js", () => ({
-	readFile: vi.fn(async () => ({})),
+  readFile: vi.fn(async () => ({})),
 }));
 
 vi.mock("../../../lib/logger.js", () => ({
-	default: vi.fn(),
+  default: vi.fn(),
 }));
 
 vi.mock("ws", () => ({
-	WebSocketServer: vi.fn(function MockWebSocketServer() {
-		this.on = vi.fn((eventName, callback) => {
-			wsServerHandlers[eventName] = callback;
-			return this;
-		});
-		this.handleUpgrade = vi.fn((_request, _socket, _head, callback) => {
-			callback({
-				on: vi.fn(),
-				readyState: 1,
-				send: vi.fn(),
-				ping: vi.fn(),
-			});
-		});
-		this.emit = vi.fn((eventName, ws) => {
-			if (eventName === "connection" && wsServerHandlers.connection) {
-				wsServerHandlers.connection(ws);
-			}
-		});
-		return this;
-	}),
+  WebSocketServer: vi.fn(function MockWebSocketServer() {
+    this.on = vi.fn((eventName, callback) => {
+      wsServerHandlers[eventName] = callback;
+      return this;
+    });
+    this.handleUpgrade = vi.fn((_request, _socket, _head, callback) => {
+      callback({
+        on: vi.fn(),
+        readyState: 1,
+        send: vi.fn(),
+        ping: vi.fn(),
+      });
+    });
+    this.emit = vi.fn((eventName, ws) => {
+      if (eventName === "connection" && wsServerHandlers.connection) {
+        wsServerHandlers.connection(ws);
+      }
+    });
+    return this;
+  }),
 }));
 
 const { default: Watcher } = await import("../../../lib/init/watcher.js");
 const { default: mockLogger } = await import("../../../lib/logger.js");
 
 describe("Watcher", () => {
-	let mockServer;
-	let consoleInfoSpy;
+  let mockServer;
+  let consoleInfoSpy;
 
-	beforeEach(() => {
-		vi.useFakeTimers();
-		vi.clearAllMocks();
-		for (const key of Object.keys(chokidarOnHandlers)) delete chokidarOnHandlers[key];
-		for (const key of Object.keys(wsServerHandlers)) delete wsServerHandlers[key];
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    for (const key of Object.keys(chokidarOnHandlers))
+      delete chokidarOnHandlers[key];
+    for (const key of Object.keys(wsServerHandlers))
+      delete wsServerHandlers[key];
 
-		consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
-		mockServer = {
-			on: vi.fn(),
-		};
+    consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    mockServer = {
+      on: vi.fn(),
+    };
 
-		global.config = {
-			...defaultConfig.defaultUserConfig,
-			components: {
-				folder: "lib",
-				ignores: [],
-			},
-			assets: {
-				root: "",
-				folder: [],
-				css: [],
-				js: [],
-				customProperties: {
-					files: [],
-				},
-				shared: {
-					css: [],
-					js: [],
-				},
-			},
-			docs: {
-				folder: null,
-			},
-			files: {
-				...defaultConfig.defaultUserConfig.files,
-				templates: {
-					...defaultConfig.defaultUserConfig.files.templates,
-					extension: "twig",
-				},
-			},
-			extensions: [],
-			watch: {
-				...defaultConfig.defaultUserConfig.watch,
-				sources: [
-					{
-						id: "components",
-						type: "dir",
-						path: "lib",
-						recursive: true,
-					},
-				],
-				report: {
-					...defaultConfig.defaultUserConfig.watch.report,
-					enabled: true,
-					onStart: true,
-					format: "summary",
-					useColors: false,
-				},
-			},
-		};
+    global.config = {
+      ...defaultConfig.defaultUserConfig,
+      components: {
+        folder: "lib",
+        ignores: [],
+      },
+      assets: {
+        root: "",
+        folder: [],
+        css: [],
+        js: [],
+        customProperties: {
+          files: [],
+        },
+        shared: {
+          css: [],
+          js: [],
+        },
+      },
+      docs: {
+        folder: null,
+      },
+      files: {
+        ...defaultConfig.defaultUserConfig.files,
+        templates: {
+          ...defaultConfig.defaultUserConfig.files.templates,
+          extension: "twig",
+        },
+      },
+      extensions: [],
+      watch: {
+        ...defaultConfig.defaultUserConfig.watch,
+        sources: [
+          {
+            id: "components",
+            type: "dir",
+            path: "lib",
+            recursive: true,
+          },
+        ],
+        behavior: {
+          ...defaultConfig.defaultUserConfig.watch.behavior,
+          startupGraceMs: 0,
+        },
+        report: {
+          ...defaultConfig.defaultUserConfig.watch.report,
+          enabled: true,
+          onStart: true,
+          format: "summary",
+          useColors: false,
+        },
+      },
+    };
 
-		global.state = {
-			fileContents: {},
-			partials: {},
-		};
-	});
+    global.state = {
+      fileContents: {},
+      partials: {},
+    };
+  });
 
-	afterEach(() => {
-		vi.runOnlyPendingTimers();
-		vi.useRealTimers();
-		delete global.config;
-		delete global.state;
-		vi.restoreAllMocks();
-	});
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    delete global.config;
+    delete global.state;
+    vi.restoreAllMocks();
+  });
 
-	test("starts chokidar with configured sources", () => {
-		Watcher(mockServer);
+  test("starts chokidar with configured sources", () => {
+    Watcher(mockServer);
 
-		expect(watchMock).toHaveBeenCalledTimes(1);
-		expect(watchMock).toHaveBeenCalledWith(
-			expect.arrayContaining([expect.stringMatching(/lib$/)]),
-			expect.objectContaining({
-				ignoreInitial: true,
-				persistent: true,
-			}),
-		);
-		expect(consoleInfoSpy).toHaveBeenCalled();
-	});
+    expect(watchMock).toHaveBeenCalledTimes(1);
+    expect(watchMock).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.stringMatching(/lib$/)]),
+      expect.objectContaining({
+        ignoreInitial: true,
+        persistent: true,
+      }),
+    );
+    expect(consoleInfoSpy).toHaveBeenCalled();
+  });
 
-	test("coalesces repeated events for same path", async () => {
-		Watcher(mockServer);
+  test("coalesces repeated events for same path", async () => {
+    Watcher(mockServer);
 
-		chokidarOnHandlers.all("change", "lib/example.txt");
-		chokidarOnHandlers.all("change", "lib/example.txt");
-		await vi.advanceTimersByTimeAsync(150);
+    chokidarOnHandlers.all("change", "lib/example.txt");
+    chokidarOnHandlers.all("change", "lib/example.txt");
+    await vi.advanceTimersByTimeAsync(150);
 
-		expect(mockSetState).toHaveBeenCalledTimes(1);
-		const updatingStartedCalls = mockLogger.mock.calls.filter(
-			([type, message]) =>
-				type === "info" &&
-				typeof message === "string" &&
-				message.includes("miyagi is updating the state"),
-		);
-		expect(updatingStartedCalls).toHaveLength(1);
-		expect(mockSetState).toHaveBeenCalledWith({
-			sourceTree: true,
-			fileContents: true,
-			menu: true,
-			partials: true,
-		});
-	});
+    expect(mockSetState).toHaveBeenCalledTimes(1);
+    const updatingStartedCalls = mockLogger.mock.calls.filter(
+      ([type, message]) =>
+        type === "info" &&
+        typeof message === "string" &&
+        message.includes("miyagi is updating the state"),
+    );
+    expect(updatingStartedCalls).toHaveLength(1);
+    expect(mockSetState).toHaveBeenCalledWith({
+      sourceTree: true,
+      fileContents: true,
+      menu: true,
+      partials: true,
+    });
+  });
 
-	test("prints resolved source list only when debug.logResolvedSources is enabled", () => {
-		global.config.watch.report.format = "pretty";
-		global.config.watch.debug.logResolvedSources = false;
-		Watcher(mockServer);
+  test("prints resolved source list only when debug.logResolvedSources is enabled", () => {
+    global.config.watch.report.format = "pretty";
+    global.config.watch.debug.logResolvedSources = false;
+    Watcher(mockServer);
 
-		expect(
-			consoleInfoSpy.mock.calls.some(([line]) =>
-				String(line).includes("Resolved sources:"),
-			),
-		).toBe(false);
+    expect(
+      consoleInfoSpy.mock.calls.some(([line]) =>
+        String(line).includes("Resolved sources:"),
+      ),
+    ).toBe(false);
 
-		consoleInfoSpy.mockClear();
-		global.config.watch.debug.logResolvedSources = true;
-		Watcher(mockServer);
+    consoleInfoSpy.mockClear();
+    global.config.watch.debug.logResolvedSources = true;
+    Watcher(mockServer);
 
-		expect(
-			consoleInfoSpy.mock.calls.some(([line]) =>
-				String(line).includes("Resolved sources:"),
-			),
-		).toBe(true);
-	});
+    expect(
+      consoleInfoSpy.mock.calls.some(([line]) =>
+        String(line).includes("Resolved sources:"),
+      ),
+    ).toBe(true);
+  });
 
-	test("sends structured reload payload to websocket clients", async () => {
-		Watcher(mockServer);
+  test("sends structured reload payload to websocket clients", async () => {
+    Watcher(mockServer);
 
-		const upgradeHandler = mockServer.on.mock.calls.find(
-			([eventName]) => eventName === "upgrade",
-		)[1];
+    const upgradeHandler = mockServer.on.mock.calls.find(
+      ([eventName]) => eventName === "upgrade",
+    )[1];
 
-		const socket = {
-			destroy: vi.fn(),
-		};
+    const socket = {
+      destroy: vi.fn(),
+    };
 
-		upgradeHandler(
-			{
-				url: "/__miyagi_ws",
-				headers: { host: "localhost:5000" },
-			},
-			socket,
-			Buffer.from(""),
-		);
+    upgradeHandler(
+      {
+        url: "/__miyagi_ws",
+        headers: { host: "localhost:5000" },
+      },
+      socket,
+      Buffer.from(""),
+    );
 
-		const wsClient = {
-			on: vi.fn(),
-			readyState: 1,
-			send: vi.fn(),
-			ping: vi.fn(),
-		};
-		wsServerHandlers.connection(wsClient);
+    const wsClient = {
+      on: vi.fn(),
+      readyState: 1,
+      send: vi.fn(),
+      ping: vi.fn(),
+    };
+    wsServerHandlers.connection(wsClient);
 
-		chokidarOnHandlers.all("change", "lib/example.txt");
-		await vi.advanceTimersByTimeAsync(150);
+    chokidarOnHandlers.all("change", "lib/example.txt");
+    await vi.advanceTimersByTimeAsync(150);
 
-		expect(wsClient.send).toHaveBeenCalledTimes(1);
-		expect(JSON.parse(wsClient.send.mock.calls[0][0])).toEqual(
-			expect.objectContaining({
-				type: "reload",
-				scope: "parent",
-			}),
-		);
-	});
+    expect(wsClient.send).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(wsClient.send.mock.calls[0][0])).toEqual(
+      expect.objectContaining({
+        type: "reload",
+        scope: "parent",
+      }),
+    );
+  });
+
+  test("suppresses events during startup grace period", async () => {
+    global.config.watch.behavior = {
+      ...global.config.watch.behavior,
+      startupGraceMs: 300,
+    };
+
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(1100)
+      .mockReturnValueOnce(1400);
+
+    Watcher(mockServer);
+
+    chokidarOnHandlers.all("change", "lib/example.txt");
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(mockSetState).not.toHaveBeenCalled();
+
+    chokidarOnHandlers.all("change", "lib/example.txt");
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(mockSetState).toHaveBeenCalledTimes(1);
+  });
 });
-


### PR DESCRIPTION
## Summary

Fixes three related issues discovered during development: spurious file-change events flooding the console on cold start, CSS/JS changes silently not triggering browser reload, and a crash in the `/component` route handler.

## What changed

**Router crash (`lib/init/router.js`):**

- Added missing `return` before `res.redirect` in the `/component` handler — without it, execution fell through to `routesEntry.type` on an undefined value, causing `TypeError: Cannot read properties of undefined (reading 'type')`

**Watcher startup grace period (`lib/init/watcher.js`, `lib/default-config.js`):**

- Added `watch.behavior.startupGraceMs` (default `500`) — silently drops file events that arrive within this window after chokidar initializes, preventing parallel build processes (esbuild, cp, etc.) from triggering unnecessary state updates during startup
- Configurable per-project; set to `0` to disable

**Reload rule defaults (`lib/default-config.js`):**

- Changed `componentAsset`, `globalCss`, `globalJs` reload rules from `"none"` to `"iframe"` so the watch-build-reload cycle works out of the box
- Updated legacy `ui.reloadAfterChanges.componentAssets` default to `true` for consistency

**Tests (`tests/lib/init/watcher.test.js`):**

- Existing tests set `startupGraceMs: 0` to remain unaffected
- New test verifies events during the grace window are suppressed and events after it are processed

**Docs (`docs/configuration/options.md`, `docs/configuration/default-configuration.md`):**

- Documented `startupGraceMs` under `watch.behavior`
- Updated reload rule defaults and `ui.reloadAfterChanges.componentAssets` default throughout

## Testing

- `pnpm test` — all 150 tests pass
- `pnpm lint` — no new lint issues


Made with [Cursor](https://cursor.com)