### PR TITLE
feat(html-validation): add validate-html CLI command and JS API

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -12,6 +12,11 @@ import {
   toSchemaValidationResult,
   validateSchemas,
 } from "../lib/validator/schemas.js";
+import {
+  validateAllHtml as validateAllHtmlImpl,
+  validateComponentHtml as validateComponentHtmlImpl,
+} from "../lib/validator/html.js";
+import { generateMarkdownReport } from "../lib/validator/html-report.js";
 
 /**
  * @param {object} obj
@@ -307,6 +312,54 @@ function getComponentsObject(component) {
  * @param {Map<string, Array<object>>} params.errorMap
  * @returns {Array<object>}
  */
+/**
+ * @param {object} [options]
+ * @param {object} [options.htmlValidateConfig]
+ * @returns {Promise<object>}
+ */
+export const validateHtml = async (options = {}) => {
+  global.app = await init("api");
+  const results = await validateAllHtmlImpl(options);
+  const report = generateMarkdownReport(results);
+  return {
+    success: results.summary.failed === 0,
+    data: { results, report },
+  };
+};
+
+/**
+ * @param {object} obj
+ * @param {string|null} obj.component
+ * @param {object} [obj.htmlValidateConfig]
+ * @returns {Promise<object>}
+ */
+export const validateHtmlComponent = async (
+  { component, ...options } = { component: null },
+) => {
+  if (!component)
+    return {
+      success: false,
+      message:
+        'Please pass a component to `validateHtmlComponent` ({ component: "name" }).',
+    };
+
+  global.app = await init("api");
+
+  const componentObject = getComponentsObject(component);
+
+  if (!componentObject)
+    return {
+      success: false,
+      message: `Component "${component}" does not exist.`,
+    };
+
+  const result = await validateComponentHtmlImpl(componentObject, options);
+  return {
+    success: result.variations.every((v) => v.valid),
+    data: result,
+  };
+};
+
 function getLintComponentErrorsInRouteOrder({ components, errorMap }) {
   return components
     .map((route) => {

--- a/docs/cli-commands/validating-html.md
+++ b/docs/cli-commands/validating-html.md
@@ -1,0 +1,100 @@
+# Validating HTML
+
+_miyagi_ can validate the rendered HTML of your components to catch issues like unclosed tags, duplicate attributes, or accessibility problems.
+
+## Render mode
+
+Validate all components by rendering them on-the-fly:
+
+```bash
+miyagi validate-html
+```
+
+Validate a single component:
+
+```bash
+miyagi validate-html path/to/component
+```
+
+In render mode, _miyagi_ renders each component variation using its mock data, then validates the resulting HTML fragment.
+
+## Files mode
+
+Validate pre-existing HTML files (e.g. from a static build) using a glob pattern:
+
+```bash
+miyagi validate-html --files "build/miyagi/component-templates-*-variation!(*-embedded).html"
+```
+
+This is useful in CI pipelines where you have already generated a static build and want to validate the output without re-rendering.
+
+In files mode, _miyagi_ validates each file as a full HTML document (including `<!DOCTYPE html>`, `<html>`, `<head>`, etc.).
+
+## Options
+
+### `--files`, `-f`
+
+Glob pattern pointing to HTML files to validate. When provided, _miyagi_ uses files mode instead of render mode.
+
+### `--output`, `-o`
+
+Path for the Markdown report file. Defaults to `html-validation-report.md`.
+
+```bash
+miyagi validate-html --output reports/html-report.md
+```
+
+### `--verbose`, `-v`
+
+Enable additional logging.
+
+## Configuration
+
+You can configure HTML validation in your `.miyagi.js` or `.miyagi.mjs`:
+
+```js
+export default {
+  htmlValidation: {
+    output: "html-validation-report.md",
+    htmlValidateConfig: {
+      extends: ["html-validate:recommended"],
+      rules: {
+        "doctype-style": "off",
+        "missing-doctype": "off",
+        "no-missing-references": "off",
+      },
+    },
+  },
+};
+```
+
+The `htmlValidateConfig` object is passed directly to [html-validate](https://html-validate.org/). You can use any configuration options supported by the library, including custom rules and presets.
+
+## Report format
+
+The command generates a Markdown report containing:
+
+1. A summary with total component counts, pass/fail status, and error/warning totals
+2. A table listing every component with its status
+3. Detailed error tables for each failed component and variation, including line numbers, column numbers, rule IDs, and messages
+
+## CI usage
+
+The command exits with code `4` when validation errors are found and `0` when all HTML is valid, making it suitable for CI pipelines:
+
+```bash
+miyagi validate-html || exit 1
+```
+
+Or validate build output:
+
+```bash
+miyagi build
+miyagi validate-html --files "build/miyagi/component-templates-*-variation!(*-embedded).html"
+```
+
+## Exit codes
+
+- `0` — all HTML is valid
+- `2` — CLI usage error (e.g. component not found)
+- `4` — validation errors found

--- a/docs/configuration/default-configuration.md
+++ b/docs/configuration/default-configuration.md
@@ -60,10 +60,10 @@ export default {
           "html-validate:recommended"
         ],
         rules: {
-          "doctype-style": "off",
-          "input-missing-label": "error",
-          "missing-doctype": "off",
-          "no-missing-references": "off"
+          doctype-style: "off",
+          input-missing-label: "error",
+          missing-doctype: "off",
+          no-missing-references: "off"
         }
       }
     },

--- a/docs/configuration/default-configuration.md
+++ b/docs/configuration/default-configuration.md
@@ -60,9 +60,10 @@ export default {
           "html-validate:recommended"
         ],
         rules: {
-          doctype-style: "off",
-          missing-doctype: "off",
-          no-missing-references: "off"
+          "doctype-style": "off",
+          "input-missing-label": "error",
+          "missing-doctype": "off",
+          "no-missing-references": "off"
         }
       }
     },

--- a/docs/configuration/default-configuration.md
+++ b/docs/configuration/default-configuration.md
@@ -53,6 +53,19 @@ export default {
   lint: {
       logLevel: "error"
     },
+  htmlValidation: {
+      output: "html-validation-report.md",
+      htmlValidateConfig: {
+        extends: [
+          "html-validate:recommended"
+        ],
+        rules: {
+          doctype-style: "off",
+          missing-doctype: "off",
+          no-missing-references: "off"
+        }
+      }
+    },
   extensions: [],
   files: {
       css: {

--- a/docs/javascript-api.md
+++ b/docs/javascript-api.md
@@ -181,6 +181,88 @@ Promise<{
 }>
 ```
 
+### `validateHtml`
+
+Validates the rendered HTML for all components and returns the results along with a Markdown report.
+
+#### Options
+
+```js
+{
+  htmlValidateConfig: Object // Optional — html-validate configuration override
+}
+```
+
+#### Response
+
+```js
+Promise<{
+ success: Boolean, // true if all components pass validation
+ data: {
+  results: {
+   components: [{
+    component: String, // Component path
+    variations: [{
+     name: String, // Variation name
+     valid: Boolean,
+     messages: [{
+      severity: Number, // 1=warning, 2=error
+      message: String,
+      ruleId: String,
+      line: Number,
+      column: Number
+     }]
+    }]
+   }],
+   summary: {
+    total: Number,
+    passed: Number,
+    failed: Number,
+    errors: Number,
+    warnings: Number
+   }
+  },
+  report: String // Markdown-formatted report
+ }
+}>
+```
+
+### `validateHtmlComponent`
+
+Validates the rendered HTML for a single component (all variations).
+
+#### Options
+
+```js
+{
+  component: String, // Required — Path to the component directory, relative from config.components.folder.
+  htmlValidateConfig: Object // Optional — html-validate configuration override
+}
+```
+
+#### Response
+
+```js
+Promise<{
+ success: Boolean, // true if all variations pass validation
+ data: {
+  component: String,
+  variations: [{
+   name: String,
+   valid: Boolean,
+   messages: [{
+    severity: Number,
+    message: String,
+    ruleId: String,
+    line: Number,
+    column: Number
+   }]
+  }]
+ },
+ message: String // Optional — Error message if component not found
+}>
+```
+
 ## Usage
 
 ```js

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -2,8 +2,10 @@ import lintImport from "./lint.js";
 import componentImport from "./component.js";
 import drupalAssetsImport from "./drupal-assets.js";
 import doctorImport from "./doctor.js";
+import validateHtmlImport from "./validate-html.js";
 
 export const lint = lintImport;
 export const component = componentImport;
 export const drupalAssets = drupalAssetsImport;
 export const doctor = doctorImport;
+export const validateHtml = validateHtmlImport;

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -9,6 +9,7 @@ import {
   component as createComponentViaCli,
   drupalAssets,
   doctor,
+  validateHtml as validateHtmlCli,
 } from "./index.js";
 import { EXIT_CODES, MiyagiError } from "../errors.js";
 
@@ -220,6 +221,11 @@ async function runDrupalAssetsCommand(args) {
  * @param {object} args
  * @returns {Promise<object>}
  */
+async function runValidateHtmlCommand(args) {
+  applyCliEnv(args);
+  return await validateHtmlCli(args);
+}
+
 async function runDoctorCommand(args) {
   applyCliEnv(args);
   return await doctor(args);
@@ -268,6 +274,7 @@ export async function runCli(argv = process.argv) {
       new: runComponentCommand,
       mocks: runMocksCommand,
       lint: runLintCommand,
+      validateHtml: runValidateHtmlCommand,
       drupalAssets: runDrupalAssetsCommand,
       doctor: runDoctorCommand,
     },

--- a/lib/cli/validate-html.js
+++ b/lib/cli/validate-html.js
@@ -1,0 +1,110 @@
+import path from "path";
+import { writeFile } from "node:fs/promises";
+import init from "./app.js";
+import getConfig from "../config.js";
+import log from "../logger.js";
+import { t } from "../i18n/index.js";
+import { EXIT_CODES } from "../errors.js";
+import {
+  validateAllHtml,
+  validateComponentHtml,
+  validateHtmlFiles,
+} from "../validator/html.js";
+import { generateMarkdownReport } from "../validator/html-report.js";
+
+/**
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+export default async function validateHtml(args) {
+  process.env.NODE_ENV = "development";
+
+  const filesGlob = args.files;
+
+  if (filesGlob) {
+    // Files mode — validate pre-existing HTML files
+    const config = await getConfig(args);
+    global.config = config;
+    const results = await validateHtmlFiles(filesGlob);
+    return await writeReport(results, args, config);
+  }
+
+  // Render mode — render components and validate
+  const componentArg = args.component;
+  const config = await getConfig(args);
+  global.app = await init(config);
+
+  let results;
+
+  if (componentArg) {
+    const component = global.state.routes.find(
+      ({ alias }) =>
+        alias === path.relative(config.components.folder, componentArg),
+    );
+
+    if (!component) {
+      const message = t("htmlValidation.componentNotFound").replace("{{component}}", componentArg);
+      log("error", message);
+      return {
+        success: false,
+        code: EXIT_CODES.CLI_USAGE_ERROR,
+        shouldExit: true,
+        message,
+      };
+    }
+
+    const result = await validateComponentHtml(component);
+    results = {
+      components: [result],
+      summary: {
+        total: 1,
+        passed: result.variations.every((v) => v.valid) ? 1 : 0,
+        failed: result.variations.some((v) => !v.valid) ? 1 : 0,
+        errors: result.variations.reduce(
+          (sum, v) =>
+            sum + v.messages.filter((m) => m.severity === 2).length,
+          0,
+        ),
+        warnings: result.variations.reduce(
+          (sum, v) =>
+            sum + v.messages.filter((m) => m.severity !== 2).length,
+          0,
+        ),
+      },
+    };
+  } else {
+    results = await validateAllHtml();
+  }
+
+  return await writeReport(results, args, config);
+}
+
+/**
+ * @param {object} results
+ * @param {object} args
+ * @param {object} config
+ * @returns {Promise<object>}
+ */
+async function writeReport(results, args, config) {
+  const report = generateMarkdownReport(results);
+  const outputPath = args.output ?? config.htmlValidation?.output ?? "html-validation-report.md";
+
+  try {
+    await writeFile(outputPath, report, "utf-8");
+    log(
+      "info",
+      t("htmlValidation.reportWritten").replace("{{path}}", outputPath),
+    );
+  } catch (error) {
+    log("error", t("htmlValidation.reportWriteFailed").replace("{{error}}", error.message));
+  }
+
+  return {
+    success: results.summary.failed === 0,
+    code:
+      results.summary.failed === 0
+        ? EXIT_CODES.SUCCESS
+        : EXIT_CODES.VALIDATION_ERROR,
+    shouldExit: true,
+  };
+}

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -49,6 +49,18 @@ export default {
     lint: {
       logLevel: "error",
     },
+    htmlValidation: {
+      output: "html-validation-report.md",
+      htmlValidateConfig: {
+        extends: ["html-validate:recommended"],
+        rules: {
+          "doctype-style": "off",
+          "input-missing-label": "error",
+          "missing-doctype": "off",
+          "no-missing-references": "off",
+        },
+      },
+    },
     extensions: [],
     files: {
       css: {

--- a/lib/i18n/en.js
+++ b/lib/i18n/en.js
@@ -31,6 +31,29 @@ export default {
       done: "Finished creating component {{component}}.",
     },
   },
+  htmlValidation: {
+    all: {
+      start: "Validating rendered HTML for all components\u2026",
+      valid: "All rendered HTML is valid!",
+      invalid: {
+        one: "1 component has HTML validation errors!",
+        other: "{{amount}} components have HTML validation errors!",
+      },
+    },
+    component: {
+      start: "Validating rendered HTML for {{component}}\u2026",
+      valid: "Rendered HTML is valid!",
+      renderFailed:
+        "Could not render {{component}} variation {{variation}}.",
+    },
+    files: {
+      start: "Validating HTML files matching {{pattern}}\u2026",
+      noFilesFound: "No files found matching {{pattern}}.",
+    },
+    componentNotFound: "The component {{component}} does not seem to exist.",
+    reportWriteFailed: "Failed to write report: {{error}}.",
+    reportWritten: "HTML validation report written to {{path}}.",
+  },
   linter: {
     all: {
       start: "Validating schema files and mock data for all components…",

--- a/lib/init/args.js
+++ b/lib/init/args.js
@@ -102,6 +102,28 @@ export default function createCli(handlers, argv = process.argv) {
       commandHandler(handlers.lint),
     )
     .command(
+      "validate-html [component]",
+      "Validates rendered HTML of components and generates a Markdown report",
+      (builder) =>
+        builder
+          .positional("component", {
+            description: "Optional component path to validate (render mode)",
+            type: "string",
+          })
+          .option("files", {
+            alias: "f",
+            description:
+              "Glob pattern pointing to HTML files to validate (e.g. build/miyagi/component-*.html)",
+            type: "string",
+          })
+          .option("output", {
+            alias: "o",
+            description: "Path for the Markdown report file",
+            type: "string",
+          }),
+      commandHandler(handlers.validateHtml),
+    )
+    .command(
       "drupal-assets",
       "Resolves Drupal *.libraries.yml dependencies and updates component $assets in mock files",
       (builder) =>

--- a/lib/validator/html-report.js
+++ b/lib/validator/html-report.js
@@ -69,7 +69,9 @@ export function generateMarkdownReport(results) {
 
         for (const msg of variation.messages) {
           const severity = msg.severity === 2 ? "error" : "warning";
-          const escapedMessage = msg.message.replace(/\|/g, "\\|");
+          const escapedMessage = msg.message
+            .replace(/\\/g, "\\\\")
+            .replace(/\|/g, "\\|");
           lines.push(
             `| ${msg.line} | ${msg.column} | ${severity} | ${msg.ruleId} | ${escapedMessage} |`,
           );

--- a/lib/validator/html-report.js
+++ b/lib/validator/html-report.js
@@ -1,0 +1,83 @@
+/**
+ * Generate a Markdown report from HTML validation results.
+ * @param {object} results - output from validateAllHtml, validateComponentHtml, or validateHtmlFiles
+ * @param {Array<object>} results.components
+ * @param {object} results.summary
+ * @returns {string} Markdown-formatted report
+ */
+export function generateMarkdownReport(results) {
+  const { components, summary } = results;
+  const lines = [];
+
+  lines.push("# HTML Validation Report");
+  lines.push("");
+  lines.push(`**Date:** ${new Date().toISOString().split("T")[0]}`);
+  lines.push(
+    `**Total components:** ${summary.total} | **Passed:** ${summary.passed} | **Failed:** ${summary.failed}`,
+  );
+  lines.push(
+    `**Errors:** ${summary.errors} | **Warnings:** ${summary.warnings}`,
+  );
+  lines.push("");
+
+  // Summary table
+  lines.push("## Summary");
+  lines.push("");
+  lines.push("| Component | Status | Errors | Warnings |");
+  lines.push("|-----------|--------|--------|----------|");
+
+  for (const comp of components) {
+    const hasErrors = comp.variations.some((v) => !v.valid);
+    const status = hasErrors ? "FAIL" : "PASS";
+    let errors = 0;
+    let warnings = 0;
+
+    for (const variation of comp.variations) {
+      for (const msg of variation.messages) {
+        if (msg.severity === 2) {
+          errors++;
+        } else {
+          warnings++;
+        }
+      }
+    }
+
+    lines.push(`| ${comp.component} | ${status} | ${errors} | ${warnings} |`);
+  }
+
+  // Failed component details
+  const failedComponents = components.filter((comp) =>
+    comp.variations.some((v) => !v.valid),
+  );
+
+  if (failedComponents.length > 0) {
+    lines.push("");
+    lines.push("## Failed Components");
+
+    for (const comp of failedComponents) {
+      lines.push("");
+      lines.push(`### ${comp.component}`);
+
+      const failedVariations = comp.variations.filter((v) => !v.valid);
+
+      for (const variation of failedVariations) {
+        lines.push("");
+        lines.push(`#### ${variation.name}`);
+        lines.push("");
+        lines.push("| Line | Col | Severity | Rule | Message |");
+        lines.push("|------|-----|----------|------|---------|");
+
+        for (const msg of variation.messages) {
+          const severity = msg.severity === 2 ? "error" : "warning";
+          const escapedMessage = msg.message.replace(/\|/g, "\\|");
+          lines.push(
+            `| ${msg.line} | ${msg.column} | ${severity} | ${msg.ruleId} | ${escapedMessage} |`,
+          );
+        }
+      }
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/lib/validator/html.js
+++ b/lib/validator/html.js
@@ -1,0 +1,389 @@
+import { readFile } from "node:fs/promises";
+import { globSync } from "node:fs";
+import path from "path";
+import { HtmlValidate } from "html-validate";
+import { getComponentData } from "../mocks/index.js";
+import { t } from "../i18n/index.js";
+import log from "../logger.js";
+
+/**
+ * @param {string} templatePath
+ * @param {object} data
+ * @returns {Promise<string>}
+ */
+function renderTemplate(templatePath, data) {
+  return new Promise((resolve, reject) => {
+    global.app.render(templatePath, data, (error, result) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(result);
+      }
+    });
+  });
+}
+
+/**
+ * @param {object} htmlValidateConfig
+ * @returns {HtmlValidate}
+ */
+function createValidator(htmlValidateConfig) {
+  return new HtmlValidate(htmlValidateConfig);
+}
+
+/**
+ * @param {Array<object>} componentResults
+ * @returns {object}
+ */
+function buildSummary(componentResults) {
+  let errors = 0;
+  let warnings = 0;
+  let passed = 0;
+  let failed = 0;
+
+  for (const comp of componentResults) {
+    const hasErrors = comp.variations.some((v) => !v.valid);
+    if (hasErrors) {
+      failed++;
+    } else {
+      passed++;
+    }
+    for (const variation of comp.variations) {
+      for (const msg of variation.messages) {
+        if (msg.severity === 2) {
+          errors++;
+        } else {
+          warnings++;
+        }
+      }
+    }
+  }
+
+  return {
+    total: componentResults.length,
+    passed,
+    failed,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Validate rendered HTML for all components.
+ * @param {object} [options]
+ * @param {object} [options.htmlValidateConfig]
+ * @returns {Promise<{components: Array<object>, summary: object}>}
+ */
+export async function validateAllHtml(options = {}) {
+  const config =
+    options.htmlValidateConfig ?? global.config.htmlValidation?.htmlValidateConfig;
+  const validator = createValidator(config);
+  const components = global.state.routes.filter(
+    (route) => route.type === "components" && route.paths.tpl,
+  );
+
+  log(
+    "info",
+    t("htmlValidation.all.start"),
+  );
+
+  const componentResults = await Promise.all(
+    components.map((component) =>
+      validateSingleComponent(component, validator),
+    ),
+  );
+
+  const summary = buildSummary(componentResults);
+
+  if (summary.failed === 0) {
+    log("success", t("htmlValidation.all.valid"));
+  } else {
+    const msg =
+      summary.failed === 1
+        ? t("htmlValidation.all.invalid.one")
+        : t("htmlValidation.all.invalid.other").replace(
+            "{{amount}}",
+            summary.failed,
+          );
+    log("error", msg);
+  }
+
+  return { components: componentResults, summary };
+}
+
+/**
+ * Validate rendered HTML for a single component (all variations).
+ * @param {object} component - route object from global.state.routes
+ * @param {object} [options]
+ * @param {object} [options.htmlValidateConfig]
+ * @returns {Promise<{component: string, variations: Array<object>}>}
+ */
+export async function validateComponentHtml(component, options = {}) {
+  const config =
+    options.htmlValidateConfig ?? global.config.htmlValidation?.htmlValidateConfig;
+  const validator = createValidator(config);
+
+  log(
+    "info",
+    t("htmlValidation.component.start").replace(
+      "{{component}}",
+      component.paths.dir.short,
+    ),
+  );
+
+  const result = await validateSingleComponent(component, validator);
+
+  const allValid = result.variations.every((v) => v.valid);
+  if (allValid) {
+    log("success", t("htmlValidation.component.valid"));
+  }
+
+  return result;
+}
+
+/**
+ * @param {object} component
+ * @param {HtmlValidate} validator
+ * @returns {Promise<{component: string, variations: Array<object>}>}
+ */
+async function validateSingleComponent(component, validator) {
+  const data = await getComponentData(component);
+  const variations = [];
+
+  if (data && data.length > 0) {
+    for (const entry of data) {
+      try {
+        const html = await renderTemplate(
+          component.paths.tpl.full,
+          entry.resolved ?? {},
+        );
+        const report = await validator.validateString(html);
+        const messages = report.results.flatMap((r) =>
+          r.messages.map((msg) => ({
+            severity: msg.severity,
+            message: msg.message,
+            ruleId: msg.ruleId,
+            line: msg.line,
+            column: msg.column,
+          })),
+        );
+
+        variations.push({
+          name: entry.name,
+          valid: report.valid,
+          messages,
+        });
+      } catch (error) {
+        log(
+          "warn",
+          t("htmlValidation.component.renderFailed")
+            .replace("{{component}}", component.paths.dir.short)
+            .replace("{{variation}}", entry.name),
+        );
+        variations.push({
+          name: entry.name,
+          valid: false,
+          messages: [
+            {
+              severity: 2,
+              message: `Render error: ${error.message || error}`,
+              ruleId: "render-error",
+              line: 0,
+              column: 0,
+            },
+          ],
+        });
+      }
+    }
+  } else {
+    // No mock data — render with empty object for default variation
+    try {
+      const html = await renderTemplate(component.paths.tpl.full, {});
+      const report = await validator.validateString(html);
+      const messages = report.results.flatMap((r) =>
+        r.messages.map((msg) => ({
+          severity: msg.severity,
+          message: msg.message,
+          ruleId: msg.ruleId,
+          line: msg.line,
+          column: msg.column,
+        })),
+      );
+
+      variations.push({
+        name: "default",
+        valid: report.valid,
+        messages,
+      });
+    } catch (error) {
+      variations.push({
+        name: "default",
+        valid: false,
+        messages: [
+          {
+            severity: 2,
+            message: `Render error: ${error.message || error}`,
+            ruleId: "render-error",
+            line: 0,
+            column: 0,
+          },
+        ],
+      });
+    }
+  }
+
+  return {
+    component: component.paths.dir.short,
+    variations,
+  };
+}
+
+/**
+ * Parse component and variation name from a build output filename.
+ * Expected pattern: component-<path>-variation-<name>.html
+ * @param {string} filePath
+ * @returns {{ component: string, variation: string }}
+ */
+function parseFileName(filePath) {
+  const basename = path.basename(filePath, ".html");
+
+  const variationMatch = basename.match(/^component-(.+)-variation-(.+)$/);
+  if (variationMatch) {
+    const componentPart = variationMatch[1].replace(/-/g, "/");
+    return {
+      component: componentPart,
+      variation: variationMatch[2],
+    };
+  }
+
+  // Fallback: use full basename as component name
+  return {
+    component: basename,
+    variation: "default",
+  };
+}
+
+/**
+ * Validate pre-existing HTML files matching a glob pattern.
+ * Files are validated as full HTML documents.
+ * @param {string} globPattern
+ * @param {object} [options]
+ * @param {object} [options.htmlValidateConfig]
+ * @returns {Promise<{components: Array<object>, summary: object}>}
+ */
+export async function validateHtmlFiles(globPattern, options = {}) {
+  const baseConfig =
+    options.htmlValidateConfig ?? global.config?.htmlValidation?.htmlValidateConfig;
+
+  // For file mode, use full-document validation (don't disable doctype rules)
+  const fileConfig = {
+    ...baseConfig,
+    rules: {
+      ...(baseConfig?.rules ?? {}),
+      "doctype-style": undefined,
+      "missing-doctype": undefined,
+    },
+  };
+
+  // Remove undefined keys so they fall back to the preset defaults
+  for (const [key, value] of Object.entries(fileConfig.rules)) {
+    if (value === undefined) {
+      delete fileConfig.rules[key];
+    }
+  }
+
+  const validator = createValidator(fileConfig);
+
+  log(
+    "info",
+    t("htmlValidation.files.start").replace("{{pattern}}", globPattern),
+  );
+
+  const files = globSync(globPattern);
+
+  if (files.length === 0) {
+    log(
+      "warn",
+      t("htmlValidation.files.noFilesFound").replace(
+        "{{pattern}}",
+        globPattern,
+      ),
+    );
+    return { components: [], summary: buildSummary([]) };
+  }
+
+  // Group files by component
+  const componentMap = new Map();
+
+  for (const filePath of files) {
+    const { component, variation } = parseFileName(filePath);
+    if (!componentMap.has(component)) {
+      componentMap.set(component, []);
+    }
+    componentMap.get(component).push({ filePath, variation });
+  }
+
+  const componentResults = [];
+
+  for (const [componentName, fileEntries] of componentMap) {
+    const variations = [];
+
+    for (const { filePath, variation } of fileEntries) {
+      try {
+        const html = await readFile(filePath, "utf-8");
+        const report = await validator.validateString(html);
+        const messages = report.results.flatMap((r) =>
+          r.messages.map((msg) => ({
+            severity: msg.severity,
+            message: msg.message,
+            ruleId: msg.ruleId,
+            line: msg.line,
+            column: msg.column,
+          })),
+        );
+
+        variations.push({
+          name: variation,
+          valid: report.valid,
+          messages,
+        });
+      } catch (error) {
+        variations.push({
+          name: variation,
+          valid: false,
+          messages: [
+            {
+              severity: 2,
+              message: `File read error: ${error.message || error}`,
+              ruleId: "file-error",
+              line: 0,
+              column: 0,
+            },
+          ],
+        });
+      }
+    }
+
+    componentResults.push({
+      component: componentName,
+      variations,
+    });
+  }
+
+  const summary = buildSummary(componentResults);
+
+  if (summary.failed === 0) {
+    log("success", t("htmlValidation.all.valid"));
+  } else {
+    const msg =
+      summary.failed === 1
+        ? t("htmlValidation.all.invalid.one")
+        : t("htmlValidation.all.invalid.other").replace(
+            "{{amount}}",
+            summary.failed,
+          );
+    log("error", msg);
+  }
+
+  return { components: componentResults, summary };
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "deepmerge": "^4.3.1",
     "directory-tree": "^3.5.2",
     "express": "^5.1.0",
+    "html-validate": "^10.11.2",
     "js-yaml": "^4.1.0",
     "marked": "^17.0.2",
     "twing": "7.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      html-validate:
+        specifier: ^10.11.2
+        version: 10.11.2(vitest@4.0.16(@types/node@25.5.0)(jsdom@28.1.0)(terser@5.46.0)(yaml@2.8.2))
       js-yaml:
         specifier: ^4.1.0
         version: 4.1.1
@@ -525,6 +528,10 @@ packages:
     resolution: {integrity: sha512-kjotm7XJrJ6v+7knhPaRgaT6q8F8K2jiafwYdNHLzmV0uGLuZY43FK6smNSHUPrhq5kX2slCUy+RGG/xGqmIKA==}
     engines: {node: '>=10.13.0'}
 
+  '@html-validate/stylish@5.0.0':
+    resolution: {integrity: sha512-xjhRV9k1mWfgsOcpYlwsjUOFy3w3EnCDrqUrEw+DWdvOStMK59ts2H7GLKWZtmLI5m6Npp3qMSNReafQy9K2sA==}
+    engines: {node: ^20.11 || >= 22.16}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -639,66 +646,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -729,6 +749,12 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@sidvind/better-ajv-errors@4.0.1':
+    resolution: {integrity: sha512-6arF1ssKxItxgitPYXafUoLmsVBA6K7m9+ZGj6hLDoBl7nWpJ33EInwQUdHTle2METeWGxgQiqSex20KZRykew==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      ajv: ^7.0.0 || ^8.0.0
 
   '@sindresorhus/base62@1.0.0':
     resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
@@ -1769,6 +1795,10 @@ packages:
     resolution: {integrity: sha512-wGM28Ehmcnk2NqRORXFOTOR064L4imSw3EeOqU5bIwUf62eXGwg89WivH6VMahL8zlQHeodzvHpXplrqzrz3Nw==}
     engines: {node: '>= 10.13.0'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   global-modules@1.0.0:
     resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
     engines: {node: '>=0.10.0'}
@@ -1871,6 +1901,25 @@ packages:
   html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
+
+  html-validate@10.11.2:
+    resolution: {integrity: sha512-ZT4812sBvF77WrfTNWcaaml7xSOMDsGvw3plP4zrgcPw5RWESsRgprsVVYnaQD2lSNfD0WObZ0Ur22+xXj0TXA==}
+    engines: {node: ^20.19.0 || >= 22.16.0}
+    hasBin: true
+    peerDependencies:
+      jest: ^28.1.3 || ^29.0.3 || ^30.0.0
+      jest-diff: ^28.1.3 || ^29.0.3 || ^30.0.0
+      jest-snapshot: ^28.1.3 || ^29.0.3 || ^30.0.0
+      vitest: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.1
+    peerDependenciesMeta:
+      jest:
+        optional: true
+      jest-diff:
+        optional: true
+      jest-snapshot:
+        optional: true
+      vitest:
+        optional: true
 
   htmlparser2@7.2.0:
     resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
@@ -2105,6 +2154,10 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
@@ -2289,6 +2342,10 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
 
@@ -2442,6 +2499,10 @@ packages:
   path-root@0.1.1:
     resolution: {integrity: sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==}
     engines: {node: '>=0.10.0'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
@@ -2715,6 +2776,10 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2940,6 +3005,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -3824,6 +3892,10 @@ snapshots:
     dependencies:
       is-negated-glob: 1.0.0
 
+  '@html-validate/stylish@5.0.0':
+    dependencies:
+      kleur: 4.1.5
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -3974,6 +4046,11 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@sidvind/better-ajv-errors@4.0.1(ajv@8.18.0)':
+    dependencies:
+      ajv: 8.18.0
+      kleur: 4.1.5
 
   '@sindresorhus/base62@1.0.0': {}
 
@@ -5156,6 +5233,12 @@ snapshots:
       async-done: 2.0.0
       chokidar: 3.6.0
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   global-modules@1.0.0:
     dependencies:
       global-prefix: 1.0.2
@@ -5279,6 +5362,19 @@ snapshots:
   html-escaper@2.0.2: {}
 
   html-tags@3.3.1: {}
+
+  html-validate@10.11.2(vitest@4.0.16(@types/node@25.5.0)(jsdom@28.1.0)(terser@5.46.0)(yaml@2.8.2)):
+    dependencies:
+      '@html-validate/stylish': 5.0.0
+      '@sidvind/better-ajv-errors': 4.0.1(ajv@8.18.0)
+      ajv: 8.18.0
+      glob: 13.0.6
+      kleur: 4.1.5
+      minimist: 1.2.8
+      prompts: 2.4.2
+      semver: 7.7.4
+    optionalDependencies:
+      vitest: 4.0.16(@types/node@25.5.0)(jsdom@28.1.0)(terser@5.46.0)(yaml@2.8.2)
 
   htmlparser2@7.2.0:
     dependencies:
@@ -5501,6 +5597,8 @@ snapshots:
 
   kind-of@6.0.3: {}
 
+  kleur@3.0.3: {}
+
   kleur@4.1.5: {}
 
   known-css-properties@0.37.0: {}
@@ -5653,6 +5751,8 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  minipass@7.1.3: {}
+
   moo@0.5.2: {}
 
   morphdom@2.7.7: {}
@@ -5791,6 +5891,11 @@ snapshots:
   path-root@0.1.1:
     dependencies:
       path-root-regex: 0.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.6
+      minipass: 7.1.3
 
   path-to-regexp@8.3.0: {}
 
@@ -6026,6 +6131,11 @@ snapshots:
   prismjs@1.30.0: {}
 
   process-nextick-args@2.0.1: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   proxy-addr@2.0.7:
     dependencies:
@@ -6275,6 +6385,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 

--- a/tests/_setup/html/component-button-variation-default.html
+++ b/tests/_setup/html/component-button-variation-default.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Button</title>
+  </head>
+  <body>
+    <button type="button" class="btn btn--primary">Primary action</button>
+    <button type="button" class="btn btn--secondary" aria-disabled="true">Secondary action</button>
+    <button type="reset" class="btn btn--ghost">Reset</button>
+    <button type="submit" class="btn btn--submit">Submit form</button>
+  </body>
+</html>

--- a/tests/_setup/html/component-card-variation-default.html
+++ b/tests/_setup/html/component-card-variation-default.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Card</title>
+  </head>
+  <body>
+    <article class="card">
+      <img
+        src="thumbnail.jpg"
+        alt="A scenic mountain landscape at sunset"
+        class="card__image"
+        width="400"
+        height="300"
+      >
+      <div class="card__content">
+        <h2 class="card__title">Card Heading</h2>
+        <p class="card__description">
+          A brief description of the card's topic that gives readers enough
+          context to decide whether to read more.
+        </p>
+        <a href="/learn-more" class="card__link">
+          Learn more<span class="sr-only"> about Card Heading</span>
+        </a>
+      </div>
+    </article>
+  </body>
+</html>

--- a/tests/_setup/html/component-form-variation-invalid.html
+++ b/tests/_setup/html/component-form-variation-invalid.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Form</title>
+  </head>
+  <body>
+    <form>
+      <input type="text" placeholder="Enter your name">
+      <!-- empty heading — triggers empty-heading -->
+      <h3></h3>
+      <!-- image without alt — triggers wcag/h37 -->
+      <img src="decorative-divider.svg">
+      <!-- button without explicit type — triggers no-implicit-button-type -->
+      <button>Submit</button>
+    </form>
+  </body>
+</html>

--- a/tests/_setup/html/component-icon-variation-default.html
+++ b/tests/_setup/html/component-icon-variation-default.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Icon</title>
+  </head>
+  <body>
+    <!-- duplicate attribute — triggers no-dup-attr -->
+    <span class="icon" class="icon--star">★</span>
+    <!-- missing alt text — triggers wcag/h37 -->
+    <img src="icon-warning.svg" class="icon icon--warning">
+  </body>
+</html>

--- a/tests/lib/cli/validate-html.test.js
+++ b/tests/lib/cli/validate-html.test.js
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { EXIT_CODES } from "../../../lib/errors.js";
+
+const {
+  mockGetConfig,
+  mockInit,
+  mockValidateAllHtml,
+  mockValidateComponentHtml,
+  mockValidateHtmlFiles,
+  mockGenerateMarkdownReport,
+  mockLog,
+  mockWriteFile,
+} = vi.hoisted(() => ({
+  mockGetConfig: vi.fn(),
+  mockInit: vi.fn(),
+  mockValidateAllHtml: vi.fn(),
+  mockValidateComponentHtml: vi.fn(),
+  mockValidateHtmlFiles: vi.fn(),
+  mockGenerateMarkdownReport: vi.fn(),
+  mockLog: vi.fn(),
+  mockWriteFile: vi.fn(),
+}));
+
+vi.mock("../../../lib/config.js", () => ({
+  default: mockGetConfig,
+}));
+
+vi.mock("../../../lib/cli/app.js", () => ({
+  default: mockInit,
+}));
+
+vi.mock("../../../lib/validator/html.js", () => ({
+  validateAllHtml: mockValidateAllHtml,
+  validateComponentHtml: mockValidateComponentHtml,
+  validateHtmlFiles: mockValidateHtmlFiles,
+}));
+
+vi.mock("../../../lib/validator/html-report.js", () => ({
+  generateMarkdownReport: mockGenerateMarkdownReport,
+}));
+
+vi.mock("../../../lib/logger.js", () => ({
+  default: mockLog,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  writeFile: mockWriteFile,
+}));
+
+import validateHtml from "../../../lib/cli/validate-html.js";
+
+const baseConfig = {
+  components: { folder: "src" },
+  htmlValidation: { output: "html-validation-report.md" },
+};
+
+const passingResults = {
+  components: [
+    {
+      component: "button",
+      variations: [{ name: "default", valid: true, messages: [] }],
+    },
+  ],
+  summary: { total: 1, passed: 1, failed: 0, errors: 0, warnings: 0 },
+};
+
+const failingResults = {
+  components: [
+    {
+      component: "button",
+      variations: [
+        {
+          name: "default",
+          valid: false,
+          messages: [
+            {
+              severity: 2,
+              message: "test error",
+              ruleId: "test",
+              line: 1,
+              column: 1,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  summary: { total: 1, passed: 0, failed: 1, errors: 1, warnings: 0 },
+};
+
+describe("validate-html CLI", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.config = baseConfig;
+    global.state = {
+      routes: [
+        {
+          type: "components",
+          alias: "button",
+          paths: {
+            dir: { short: "button" },
+            tpl: { full: "/src/button/button.twig" },
+          },
+        },
+      ],
+    };
+    mockGetConfig.mockResolvedValue(baseConfig);
+    mockInit.mockResolvedValue({});
+    mockGenerateMarkdownReport.mockReturnValue("# Report");
+    mockWriteFile.mockResolvedValue();
+  });
+
+  test("validates all components in render mode", async () => {
+    mockValidateAllHtml.mockResolvedValue(passingResults);
+
+    const result = await validateHtml({});
+
+    expect(mockInit).toHaveBeenCalled();
+    expect(mockValidateAllHtml).toHaveBeenCalled();
+    expect(mockWriteFile).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.code).toBe(EXIT_CODES.SUCCESS);
+  });
+
+  test("validates a single component", async () => {
+    mockValidateComponentHtml.mockResolvedValue({
+      component: "button",
+      variations: [{ name: "default", valid: true, messages: [] }],
+    });
+
+    const result = await validateHtml({ component: "src/button" });
+
+    expect(mockValidateComponentHtml).toHaveBeenCalled();
+    expect(result.success).toBe(true);
+  });
+
+  test("returns error for non-existent component", async () => {
+    const result = await validateHtml({ component: "src/nonexistent" });
+
+    expect(result.success).toBe(false);
+    expect(result.code).toBe(EXIT_CODES.CLI_USAGE_ERROR);
+  });
+
+  test("uses files mode when --files is provided", async () => {
+    mockValidateHtmlFiles.mockResolvedValue(passingResults);
+
+    const result = await validateHtml({
+      files: "build/*.html",
+    });
+
+    expect(mockValidateHtmlFiles).toHaveBeenCalledWith("build/*.html");
+    expect(mockInit).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+  });
+
+  test("returns VALIDATION_ERROR when validation fails", async () => {
+    mockValidateAllHtml.mockResolvedValue(failingResults);
+
+    const result = await validateHtml({});
+
+    expect(result.success).toBe(false);
+    expect(result.code).toBe(EXIT_CODES.VALIDATION_ERROR);
+  });
+
+  test("uses --output for report path", async () => {
+    mockValidateAllHtml.mockResolvedValue(passingResults);
+
+    await validateHtml({ output: "custom-report.md" });
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      "custom-report.md",
+      "# Report",
+      "utf-8",
+    );
+  });
+});

--- a/tests/lib/validator/html-files.integration.test.js
+++ b/tests/lib/validator/html-files.integration.test.js
@@ -1,0 +1,105 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { validateHtmlFiles } from "../../../lib/validator/html.js";
+
+const BUTTON_FIXTURE = "tests/_setup/html/component-button-variation-default.html";
+const CARD_FIXTURE = "tests/_setup/html/component-card-variation-default.html";
+const ICON_FIXTURE = "tests/_setup/html/component-icon-variation-default.html";
+const FORM_FIXTURE = "tests/_setup/html/component-form-variation-invalid.html";
+const ALL_FIXTURES = "tests/_setup/html/component-*-variation-*.html";
+
+const testConfig = {
+  extends: ["html-validate:recommended"],
+  rules: { "input-missing-label": "error" },
+};
+
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("validateHtmlFiles — integration", () => {
+  test("button fixture passes validation", async () => {
+    const results = await validateHtmlFiles(BUTTON_FIXTURE, {
+      htmlValidateConfig: testConfig,
+    });
+
+    expect(results.summary.total).toBe(1);
+    expect(results.summary.passed).toBe(1);
+    expect(results.summary.failed).toBe(0);
+    expect(results.summary.errors).toBe(0);
+    expect(results.components[0].variations[0].valid).toBe(true);
+    expect(results.components[0].variations[0].messages).toHaveLength(0);
+  });
+
+  test("card fixture passes validation", async () => {
+    const results = await validateHtmlFiles(CARD_FIXTURE, {
+      htmlValidateConfig: testConfig,
+    });
+
+    expect(results.summary.total).toBe(1);
+    expect(results.summary.passed).toBe(1);
+    expect(results.summary.failed).toBe(0);
+    expect(results.summary.errors).toBe(0);
+    expect(results.components[0].variations[0].valid).toBe(true);
+    expect(results.components[0].variations[0].messages).toHaveLength(0);
+  });
+
+  test("icon fixture fails with duplicate attribute and missing alt text", async () => {
+    const results = await validateHtmlFiles(ICON_FIXTURE, {
+      htmlValidateConfig: testConfig,
+    });
+
+    expect(results.summary.total).toBe(1);
+    expect(results.summary.passed).toBe(0);
+    expect(results.summary.failed).toBe(1);
+    expect(results.summary.errors).toBeGreaterThanOrEqual(2);
+
+    const [component] = results.components;
+    expect(component.variations[0].valid).toBe(false);
+
+    const ruleIds = component.variations[0].messages.map((m) => m.ruleId);
+    expect(ruleIds).toContain("no-dup-attr");
+    expect(ruleIds).toContain("wcag/h37");
+  });
+
+  test("form fixture fails with unlabelled input, empty heading, missing alt, and implicit button type", async () => {
+    const results = await validateHtmlFiles(FORM_FIXTURE, {
+      htmlValidateConfig: testConfig,
+    });
+
+    expect(results.summary.total).toBe(1);
+    expect(results.summary.passed).toBe(0);
+    expect(results.summary.failed).toBe(1);
+    expect(results.summary.errors).toBeGreaterThanOrEqual(4);
+
+    const [component] = results.components;
+    expect(component.variations[0].valid).toBe(false);
+
+    const ruleIds = component.variations[0].messages.map((m) => m.ruleId);
+    expect(ruleIds).toContain("input-missing-label");
+    expect(ruleIds).toContain("empty-heading");
+    expect(ruleIds).toContain("wcag/h37");
+    expect(ruleIds).toContain("no-implicit-button-type");
+  });
+
+  test("glob matching all fixtures produces correct summary", async () => {
+    const results = await validateHtmlFiles(ALL_FIXTURES, {
+      htmlValidateConfig: testConfig,
+    });
+
+    expect(results.summary.total).toBe(4);
+    expect(results.summary.passed).toBe(2);
+    expect(results.summary.failed).toBe(2);
+
+    const componentNames = results.components.map((c) => c.component);
+    expect(componentNames).toContain("button");
+    expect(componentNames).toContain("card");
+    expect(componentNames).toContain("icon");
+    expect(componentNames).toContain("form");
+  });
+});

--- a/tests/lib/validator/html-report.integration.test.js
+++ b/tests/lib/validator/html-report.integration.test.js
@@ -1,0 +1,82 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, readFile, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "path";
+import { validateHtmlFiles } from "../../../lib/validator/html.js";
+import { generateMarkdownReport } from "../../../lib/validator/html-report.js";
+
+const BUTTON_FIXTURE = "tests/_setup/html/component-button-variation-default.html";
+const ALL_FIXTURES = "tests/_setup/html/component-*-variation-*.html";
+
+const testConfig = {
+  extends: ["html-validate:recommended"],
+  rules: { "input-missing-label": "error" },
+};
+
+let tmpDir;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(tmpdir(), "miyagi-html-report-test-"));
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true });
+  vi.restoreAllMocks();
+});
+
+describe("generateMarkdownReport — integration (real files)", () => {
+  test("writes report from real validation results and reads back expected content", async () => {
+    const results = await validateHtmlFiles(ALL_FIXTURES, {
+      htmlValidateConfig: testConfig,
+    });
+    const report = generateMarkdownReport(results);
+    const outputPath = path.join(tmpDir, "report.md");
+
+    await writeFile(outputPath, report, "utf-8");
+    const content = await readFile(outputPath, "utf-8");
+
+    expect(content).toContain("# HTML Validation Report");
+    expect(content).toContain("**Passed:** 2");
+    expect(content).toContain("**Failed:** 2");
+
+    // Valid components appear as PASS with no errors
+    expect(content).toContain("| button | PASS | 0 | 0 |");
+    expect(content).toContain("| card | PASS | 0 | 0 |");
+
+    // Invalid components appear in the summary table as FAIL
+    expect(content).toMatch(/\| icon \| FAIL \| [1-9]/);
+    expect(content).toMatch(/\| form \| FAIL \| [1-9]/);
+
+    // Failed component detail sections are present
+    expect(content).toContain("## Failed Components");
+    expect(content).toContain("### icon");
+    expect(content).toContain("### form");
+
+    // Specific rule IDs appear in the detail tables
+    expect(content).toContain("no-dup-attr");
+    expect(content).toContain("wcag/h37");
+    expect(content).toContain("no-implicit-button-type");
+    expect(content).toContain("input-missing-label");
+    expect(content).toContain("empty-heading");
+    expect(content).toContain("no-implicit-button-type");
+  });
+
+  test("report for all-valid files contains no Failed Components section", async () => {
+    const results = await validateHtmlFiles(BUTTON_FIXTURE, {
+      htmlValidateConfig: testConfig,
+    });
+    const report = generateMarkdownReport(results);
+    const outputPath = path.join(tmpDir, "valid-report.md");
+
+    await writeFile(outputPath, report, "utf-8");
+    const content = await readFile(outputPath, "utf-8");
+
+    expect(content).toContain("**Passed:** 1");
+    expect(content).toContain("**Failed:** 0");
+    expect(content).toContain("| button | PASS | 0 | 0 |");
+    expect(content).not.toContain("## Failed Components");
+  });
+});

--- a/tests/lib/validator/html-report.test.js
+++ b/tests/lib/validator/html-report.test.js
@@ -1,0 +1,135 @@
+import { describe, test, expect } from "vitest";
+import { generateMarkdownReport } from "../../../lib/validator/html-report.js";
+
+describe("generateMarkdownReport", () => {
+  test("generates report for all-passing results", () => {
+    const results = {
+      components: [
+        {
+          component: "button",
+          variations: [
+            { name: "default", valid: true, messages: [] },
+            { name: "variant", valid: true, messages: [] },
+          ],
+        },
+      ],
+      summary: { total: 1, passed: 1, failed: 0, errors: 0, warnings: 0 },
+    };
+
+    const report = generateMarkdownReport(results);
+
+    expect(report).toContain("# HTML Validation Report");
+    expect(report).toContain("**Passed:** 1");
+    expect(report).toContain("**Failed:** 0");
+    expect(report).toContain("| button | PASS | 0 | 0 |");
+    expect(report).not.toContain("## Failed Components");
+  });
+
+  test("generates report with failed components", () => {
+    const results = {
+      components: [
+        {
+          component: "button",
+          variations: [{ name: "default", valid: true, messages: [] }],
+        },
+        {
+          component: "icon",
+          variations: [
+            {
+              name: "default",
+              valid: false,
+              messages: [
+                {
+                  severity: 2,
+                  message: 'Attribute "class" duplicated',
+                  ruleId: "no-dup-attr",
+                  line: 3,
+                  column: 5,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      summary: { total: 2, passed: 1, failed: 1, errors: 1, warnings: 0 },
+    };
+
+    const report = generateMarkdownReport(results);
+
+    expect(report).toContain("**Failed:** 1");
+    expect(report).toContain("| button | PASS | 0 | 0 |");
+    expect(report).toContain("| icon | FAIL | 1 | 0 |");
+    expect(report).toContain("## Failed Components");
+    expect(report).toContain("### icon");
+    expect(report).toContain("#### default");
+    expect(report).toContain("| 3 | 5 | error | no-dup-attr |");
+  });
+
+  test("escapes pipe characters in messages", () => {
+    const results = {
+      components: [
+        {
+          component: "test",
+          variations: [
+            {
+              name: "default",
+              valid: false,
+              messages: [
+                {
+                  severity: 2,
+                  message: "value must be a|b",
+                  ruleId: "test-rule",
+                  line: 1,
+                  column: 1,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      summary: { total: 1, passed: 0, failed: 1, errors: 1, warnings: 0 },
+    };
+
+    const report = generateMarkdownReport(results);
+    expect(report).toContain("value must be a\\|b");
+  });
+
+  test("includes date", () => {
+    const results = {
+      components: [],
+      summary: { total: 0, passed: 0, failed: 0, errors: 0, warnings: 0 },
+    };
+
+    const report = generateMarkdownReport(results);
+    expect(report).toMatch(/\*\*Date:\*\* \d{4}-\d{2}-\d{2}/);
+  });
+
+  test("includes warnings with correct severity label", () => {
+    const results = {
+      components: [
+        {
+          component: "test",
+          variations: [
+            {
+              name: "default",
+              valid: false,
+              messages: [
+                {
+                  severity: 1,
+                  message: "Consider using native element",
+                  ruleId: "prefer-native-element",
+                  line: 2,
+                  column: 1,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      summary: { total: 1, passed: 0, failed: 1, errors: 0, warnings: 1 },
+    };
+
+    const report = generateMarkdownReport(results);
+    expect(report).toContain("| 2 | 1 | warning | prefer-native-element |");
+  });
+});

--- a/tests/lib/validator/html.test.js
+++ b/tests/lib/validator/html.test.js
@@ -1,0 +1,86 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import init from "../../../lib/index.js";
+import {
+  validateAllHtml,
+  validateComponentHtml,
+  validateHtmlFiles,
+} from "../../../lib/validator/html.js";
+
+beforeAll(() => (process.env.MIYAGI_JS_API = true));
+afterAll(() => (process.env.MIYAGI_JS_API = false));
+beforeEach(() => {
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("validateComponentHtml", () => {
+  test("validates a component with valid HTML", async () => {
+    const component = await getComponentsObject("button");
+    const result = await validateComponentHtml(component);
+
+    expect(result.component).toBe("button");
+    expect(result.variations.length).toBeGreaterThan(0);
+    expect(result.variations[0]).toHaveProperty("name");
+    expect(result.variations[0]).toHaveProperty("valid");
+    expect(result.variations[0]).toHaveProperty("messages");
+  });
+
+  test("includes all variations", async () => {
+    const component = await getComponentsObject("button");
+    const result = await validateComponentHtml(component);
+
+    const names = result.variations.map((v) => v.name);
+    expect(names).toContain("default");
+    expect(names).toContain("variant");
+  });
+});
+
+describe("validateAllHtml", () => {
+  test("returns results for all components", async () => {
+    global.app = await init("api");
+    const results = await validateAllHtml();
+
+    expect(results).toHaveProperty("components");
+    expect(results).toHaveProperty("summary");
+    expect(results.components.length).toBeGreaterThan(0);
+    expect(results.summary).toHaveProperty("total");
+    expect(results.summary).toHaveProperty("passed");
+    expect(results.summary).toHaveProperty("failed");
+    expect(results.summary).toHaveProperty("errors");
+    expect(results.summary).toHaveProperty("warnings");
+    expect(results.summary.total).toBe(results.components.length);
+  });
+});
+
+describe("validateHtmlFiles", () => {
+  test("returns empty results for non-matching glob", async () => {
+    global.app = await init("api");
+    const results = await validateHtmlFiles(
+      "tests/_setup/nonexistent-*.html",
+    );
+
+    expect(results.components).toStrictEqual([]);
+    expect(results.summary.total).toBe(0);
+  });
+});
+
+async function getComponentsObject(component) {
+  global.app = await init("api");
+
+  return global.state.routes.find(
+    (route) => route.paths.dir.short === component,
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a new `miyagi validate-html` CLI command that renders component HTML and validates it with html-validate, or validates pre-existing HTML files via a glob pattern
- Adds `validateHtml` and `validateHtmlComponent` to the JavaScript API
- Results are written as a Markdown report (default: `html-validation-report.md`)

## What's included

- **CLI**: `validate-html [component]` with `--files` (glob) and `--output` options
- **JS API**: `validateHtml(options)` and `validateHtmlComponent({ component, ...options })`
- **Default config**: `html-validate:recommended` preset enabled out of the box, with `input-missing-label: error` and doctype/reference rules turned off for component fragment rendering
- **i18n**: All user-facing validation messages go through `lib/i18n/en.js`
- **Docs**: New `docs/cli-commands/validating-html.md` and updated `docs/javascript-api.md` and `docs/configuration/default-configuration.md`
- **Tests**: Unit tests for the validator and CLI, plus integration tests using real HTML fixture files written to and read from a temporary directory (`mkdtemp`)

## Test plan

- [ ] `pnpm test` passes (all existing + new tests green)
- [ ] `pnpm lint` passes
- [ ] `miyagi validate-html` renders and validates all components, produces a report
- [ ] `miyagi validate-html --files "build/**/*.html"` validates pre-built HTML files
- [ ] `miyagi validate-html path/to/component` validates a single component
- [ ] Report is written to the configured output path

🤖 Generated with [Claude Code](https://claude.com/claude-code)