### PR TITLE
feat: add live controls panel and mock data injection for web components

### DIFF
--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -2,6 +2,7 @@
 @import url("./shared.css");
 @import url("./main/reset.css");
 @import url("./main/menu.css");
+@import url("./main/controls.css");
 
 html {
   height: 100%;
@@ -18,11 +19,14 @@ body {
 }
 
 .Content {
+  display: flex;
+  flex-direction: column;
   grid-area: iframe;
 }
 
 .FrameWrapper {
-  height: 100%;
+  flex: 1;
+  min-height: 0;
   width: 100%;
 }
 

--- a/frontend/assets/css/main/controls.css
+++ b/frontend/assets/css/main/controls.css
@@ -1,0 +1,91 @@
+.Controls {
+  background: var(--color-Menu-background);
+  border-top: var(--divider);
+  flex: 0 0 auto;
+  padding: 0.75rem var(--spacing-x, 2rem);
+}
+
+.Controls[data-mode="floating"] {
+  bottom: 0;
+  box-shadow: 0 -4px 12px rgb(0 0 0 / 15%);
+  left: 0;
+  position: fixed;
+  right: 0;
+  z-index: var(--bottom-layer);
+}
+
+@media (width > 40rem) {
+  .Controls[data-mode="floating"] {
+    left: 16rem;
+  }
+}
+
+.Controls-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.Controls-heading {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.Controls-modeToggle {
+  background: none;
+  border: 1px solid var(--color-Outline);
+  border-radius: 0.25rem;
+  color: var(--color-Icon);
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.Controls-modeToggle:hover {
+  color: var(--color-Text);
+}
+
+.Controls-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.Controls-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 8rem;
+}
+
+.Controls-label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.875rem;
+  gap: 0.25rem;
+}
+
+.Controls-labelText {
+  color: var(--color-Text);
+  font-weight: 500;
+}
+
+.Controls-select {
+  background: var(--color-Link-active-background);
+  border: 1px solid var(--color-Outline);
+  border-radius: 0.25rem;
+  color: var(--color-Text);
+  font-family: var(--font-family);
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.Controls-checkbox {
+  cursor: pointer;
+  height: 1rem;
+  width: 1rem;
+}

--- a/frontend/assets/css/tokens.css
+++ b/frontend/assets/css/tokens.css
@@ -1,4 +1,12 @@
 html {
+  /* z-index scale */
+  --send-to-back: -1;
+  --bring-to-front: 9999;
+  --bottom-layer: 100;
+  --middle-layer: 200;
+  --top-layer: 300;
+  --backdrop: 400;
+
   --font-family:
     -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica",
     "Arial", sans-serif;

--- a/frontend/assets/css/tokens.css
+++ b/frontend/assets/css/tokens.css
@@ -6,7 +6,6 @@ html {
   --middle-layer: 200;
   --top-layer: 300;
   --backdrop: 400;
-
   --font-family:
     -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Helvetica",
     "Arial", sans-serif;

--- a/frontend/assets/js/_controls.js
+++ b/frontend/assets/js/_controls.js
@@ -1,0 +1,206 @@
+const CACHE_PREFIX = "miyagi-controls::";
+const LS_MODE_KEY = "miyagi-controls-mode";
+
+function getPanel() {
+  return document.getElementById("controls-panel");
+}
+
+function getFieldsContainer() {
+  return document.getElementById("controls-fields");
+}
+
+function hidePanel() {
+  const panel = getPanel();
+  if (!panel) {
+    return;
+  }
+  panel.hidden = true;
+  getFieldsContainer().innerHTML = "";
+}
+
+function showPanel() {
+  const panel = getPanel();
+  if (panel) {
+    panel.hidden = false;
+  }
+}
+
+function initMode() {
+  const panel = getPanel();
+  if (!panel) {
+    return;
+  }
+
+  const mode = localStorage.getItem(LS_MODE_KEY) ?? "docked";
+  panel.setAttribute("data-mode", mode);
+
+  const toggle = document.getElementById("controls-mode-toggle");
+  if (toggle) {
+    toggle.addEventListener("click", () => {
+      const next =
+        panel.getAttribute("data-mode") === "docked" ? "floating" : "docked";
+      panel.setAttribute("data-mode", next);
+      localStorage.setItem(LS_MODE_KEY, next);
+    });
+  }
+}
+
+function buildOverrideSrc(baseSrc, property, value) {
+  const url = new URL(baseSrc, window.location.origin);
+  url.searchParams.set(`overrides[${property}]`, String(value));
+  return url.pathname + url.search;
+}
+
+function updateIframe(src) {
+  const iframe = document.getElementById("iframe");
+  const frameWrapper = document.querySelector(".FrameWrapper");
+  if (!iframe || !frameWrapper) {
+    return;
+  }
+  iframe.remove();
+  iframe.src = src;
+  frameWrapper.appendChild(iframe);
+  loadControls(src);
+}
+
+function renderControls(controls, iframeSrc) {
+  const fieldsContainer = getFieldsContainer();
+  fieldsContainer.innerHTML = "";
+
+  const url = new URL(iframeSrc, window.location.origin);
+  const urlOverrides = {};
+  url.searchParams.forEach((value, key) => {
+    const match = key.match(/^overrides\[(.+)\]$/);
+    if (match) {
+      urlOverrides[match[1]] = value;
+    }
+  });
+
+  controls.forEach(({ property, type, values, current }) => {
+    const displayValue =
+      urlOverrides[property] !== undefined ? urlOverrides[property] : current;
+
+    const fieldEl = document.createElement("div");
+    fieldEl.className = "Controls-field";
+
+    const labelEl = document.createElement("label");
+    labelEl.className = "Controls-label";
+
+    const labelText = document.createElement("span");
+    labelText.className = "Controls-labelText";
+    labelText.textContent = property;
+    labelEl.appendChild(labelText);
+
+    let inputEl;
+
+    if (type === "enum") {
+      inputEl = document.createElement("select");
+      inputEl.className = "Controls-select";
+      values.forEach((value) => {
+        const option = document.createElement("option");
+        option.value = value;
+        option.textContent = value;
+        // eslint-disable-next-line eqeqeq
+        if (value == displayValue) {
+          option.selected = true;
+        }
+        inputEl.appendChild(option);
+      });
+      inputEl.addEventListener("change", () => {
+        updateIframe(buildOverrideSrc(iframeSrc, property, inputEl.value));
+      });
+    } else if (type === "boolean") {
+      inputEl = document.createElement("input");
+      inputEl.type = "checkbox";
+      inputEl.className = "Controls-checkbox";
+      inputEl.checked =
+        typeof displayValue === "string"
+          ? displayValue === "true"
+          : Boolean(displayValue);
+      inputEl.addEventListener("change", () => {
+        updateIframe(buildOverrideSrc(iframeSrc, property, inputEl.checked));
+      });
+    }
+
+    if (inputEl) {
+      labelEl.appendChild(inputEl);
+      fieldEl.appendChild(labelEl);
+      fieldsContainer.appendChild(fieldEl);
+    }
+  });
+
+  showPanel();
+}
+
+export async function loadControls(iframeSrc) {
+  const url = new URL(iframeSrc, window.location.origin);
+  const file = url.searchParams.get("file");
+  const variation = url.searchParams.get("variation");
+
+  if (!file || !variation) {
+    hidePanel();
+    return;
+  }
+
+  const cacheKey = `${CACHE_PREFIX}${file}::${variation}`;
+  let data = null;
+  try {
+    data = JSON.parse(sessionStorage.getItem(cacheKey) ?? "null");
+  } catch {
+    sessionStorage.removeItem(cacheKey);
+  }
+
+  if (!data) {
+    try {
+      const res = await fetch(
+        `/api/component-controls?file=${encodeURIComponent(file)}&variation=${encodeURIComponent(variation)}`,
+      );
+      data = await res.json();
+      sessionStorage.setItem(cacheKey, JSON.stringify(data));
+    } catch {
+      hidePanel();
+      return;
+    }
+  }
+
+  if (data.controls?.length) {
+    renderControls(data.controls, iframeSrc);
+  } else {
+    hidePanel();
+  }
+}
+
+export function invalidateControlsCache(paths) {
+  for (const key of Object.keys(sessionStorage)) {
+    if (!key.startsWith(CACHE_PREFIX)) {
+      continue;
+    }
+
+    if (!paths || paths.length === 0) {
+      sessionStorage.removeItem(key);
+      continue;
+    }
+
+    const file = key.slice(CACHE_PREFIX.length).split("::")[0];
+    if (paths.some((p) => p.includes(file))) {
+      sessionStorage.removeItem(key);
+    }
+  }
+}
+
+window.addEventListener("message", (e) => {
+  if (e.data?.type === "miyagi:invalidate-cache") {
+    invalidateControlsCache(e.data.paths ?? []);
+  }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  initMode();
+  const iframe = document.getElementById("iframe");
+  if (iframe) {
+    const src = iframe.getAttribute("src");
+    if (src) {
+      loadControls(src);
+    }
+  }
+});

--- a/frontend/assets/js/_main.js
+++ b/frontend/assets/js/_main.js
@@ -1,5 +1,6 @@
 import "./_goto.js";
 import "./_search.js";
+import { loadControls } from "./_controls.js";
 import ThemeConfigSwitcher from "./config-switcher/theme.js";
 import TextDirectionConfigSwitcher from "./config-switcher/text-direction.js";
 import DevelopmentModeConfigSwitcher from "./config-switcher/development-mode.js";
@@ -77,6 +78,7 @@ class Main {
     this.elements.iframe.remove();
     this.elements.iframe.src = src;
     this.elements.frameWrapper.appendChild(this.elements.iframe);
+    loadControls(src);
   }
 
   /**

--- a/frontend/assets/js/_socket.js
+++ b/frontend/assets/js/_socket.js
@@ -49,6 +49,22 @@ function parseScope(messageData) {
   return parseJsonScope(messageData);
 }
 
+function parseReason(messageData) {
+  try {
+    return JSON.parse(messageData).reason ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function parsePaths(messageData) {
+  try {
+    return JSON.parse(messageData).paths ?? [];
+  } catch {
+    return [];
+  }
+}
+
 function scheduleReconnect() {
   const jitter = Math.floor(Math.random() * 100);
   const delay = Math.min(retryDelay + jitter, MAX_RETRY_DELAY_MS);
@@ -67,6 +83,13 @@ function connect() {
   };
 
   websocket.onmessage = (message) => {
+    const reason = parseReason(message.data);
+    if (reason === "schema" || reason === "data") {
+      window.parent.postMessage(
+        { type: "miyagi:invalidate-cache", paths: parsePaths(message.data) },
+        "*",
+      );
+    }
     triggerReload(parseScope(message.data));
   };
 

--- a/frontend/assets/js/iframe.js
+++ b/frontend/assets/js/iframe.js
@@ -13,6 +13,18 @@ if (
   window.location = new URL(window.location).replace("&embedded=true", "");
 }
 
+document.addEventListener("DOMContentLoaded", () => {
+  const mockDataEl = document.getElementById("miyagi-mock-data");
+  if (mockDataEl) {
+    try {
+      const detail = JSON.parse(mockDataEl.textContent);
+      document.dispatchEvent(new CustomEvent("miyagi:mockdata", { detail }));
+    } catch (e) {
+      console.debug("[miyagi] Failed to parse mock data island:", e);
+    }
+  }
+});
+
 document.addEventListener("DOMContentLoaded", function () {
   const links = Array.from(document.querySelectorAll(".Component-file"));
   const styleguide = document.querySelector(".Styleguide");

--- a/frontend/views/component_variation.twig.miyagi
+++ b/frontend/views/component_variation.twig.miyagi
@@ -24,6 +24,9 @@
     {% if assets.js %}
       <script src="{{ assets.js }}"></script>
     {% endif %}
+    {% if mockDataResolved is defined %}
+    <script type="application/json" id="miyagi-mock-data">{{ mockDataResolved|replace({'</script>': '<\\/script>'})|raw }}</script>
+    {% endif %}
     <script>
       {{ theme.js }}
 

--- a/frontend/views/main.twig.miyagi
+++ b/frontend/views/main.twig.miyagi
@@ -19,6 +19,15 @@
       <div class="FrameWrapper">
         <iframe class="Frame" id="iframe" src="{{ iframeSrc }}" name="iframe" title="Components"></iframe>
       </div>
+      <div class="Controls" id="controls-panel" hidden>
+        <div class="Controls-header">
+          <h2 class="Controls-heading">Controls</h2>
+          <button class="Controls-modeToggle" id="controls-mode-toggle">
+            <span class="u-hiddenVisually">Toggle floating panel</span>
+          </button>
+        </div>
+        <div class="Controls-fields" id="controls-fields"></div>
+      </div>
     </main>
   </body>
 </html>

--- a/lib/init/router.js
+++ b/lib/init/router.js
@@ -160,8 +160,61 @@ export default function Router() {
     }
   });
 
+  global.app.get("/api/component-controls", async (req, res) => {
+    const { file, variation } = req.query;
+
+    if (!file || !variation) {
+      return res.json({ controls: [] });
+    }
+
+    const routesEntry = global.state.routes.find(
+      (route) => route.paths.dir.short === file,
+    );
+
+    if (!routesEntry) {
+      return res.json({ controls: [] });
+    }
+
+    const schemaPath = routesEntry.paths?.schema?.full;
+    const schema = schemaPath
+      ? global.state.fileContents[schemaPath]
+      : undefined;
+
+    if (!schema?.properties) {
+      return res.json({ controls: [] });
+    }
+
+    if (!getDataForComponent(routesEntry)) {
+      return res.json({ controls: [] });
+    }
+
+    const data = await getVariationData(routesEntry, decodeURI(variation));
+    const resolvedData = data?.resolved ?? {};
+    const controls = [];
+
+    for (const [property, propSchema] of Object.entries(schema.properties)) {
+      if (Array.isArray(propSchema.enum) && propSchema.enum.length > 0) {
+        controls.push({
+          property,
+          type: "enum",
+          values: propSchema.enum,
+          current:
+            resolvedData[property] ?? propSchema.default ?? propSchema.enum[0],
+        });
+      } else if (propSchema.type === "boolean") {
+        controls.push({
+          property,
+          type: "boolean",
+          current: resolvedData[property] ?? propSchema.default ?? false,
+        });
+      }
+    }
+
+    return res.json({ controls });
+  });
+
   global.app.get("/component", async (req, res) => {
-    const { file, variation, embedded } = req.query;
+    const { file, variation, embedded, overrides } = req.query;
 
     if (!file) {
       return res.redirect(302, global.config.indexPath.default);
@@ -209,6 +262,7 @@ export default function Router() {
             variation,
             cookies: req.cookies,
             data,
+            overrides: overrides ?? null,
           });
         }
 
@@ -224,6 +278,7 @@ export default function Router() {
           componentData: data?.resolved ?? {},
           componentDeclaredAssets: data?.$assets || null,
           cookies: req.cookies,
+          overrides: overrides ?? null,
         });
       }
 

--- a/lib/render/helpers/apply-overrides.js
+++ b/lib/render/helpers/apply-overrides.js
@@ -1,0 +1,36 @@
+/**
+ * Applies query-param override values to resolved component data.
+ * Values are coerced to the appropriate type based on the JSON schema.
+ * Only schema-defined properties are overridden; unknown keys are ignored.
+ *
+ * @param {object} data - the resolved mock data object
+ * @param {object} overrides - key/value overrides from req.query.overrides
+ * @param {object} [schema] - the JSON schema for the component
+ * @returns {object} a new object with overrides applied
+ */
+export default function applyOverrides(data, overrides, schema) {
+  if (!overrides || typeof overrides !== "object") {
+    return data;
+  }
+
+  const properties = schema?.properties ?? {};
+  const coerced = {};
+
+  for (const [key, value] of Object.entries(overrides)) {
+    const propSchema = properties[key];
+    if (!propSchema) continue;
+
+    if (propSchema.type === "boolean") {
+      coerced[key] = value === "true";
+    } else if (
+      Array.isArray(propSchema.enum) &&
+      propSchema.enum.every((v) => typeof v === "number")
+    ) {
+      coerced[key] = Number(value);
+    } else {
+      coerced[key] = value;
+    }
+  }
+
+  return { ...data, ...coerced };
+}

--- a/lib/render/views/iframe/variation.js
+++ b/lib/render/views/iframe/variation.js
@@ -4,6 +4,7 @@ import { t } from "../../../i18n/index.js";
 import * as helpers from "../../../helpers.js";
 import validateMocks from "../../../validator/mocks.js";
 import { getUserUiConfig, getThemeMode } from "../../helpers.js";
+import applyOverrides from "../../helpers/apply-overrides.js";
 
 /**
  * @param {object} object - parameter object
@@ -22,9 +23,16 @@ export default async function renderIframeVariation({
   cb,
   cookies,
   data,
+  overrides,
 }) {
   const rawComponentData = (data && data.raw) ?? null;
-  const componentData = (data && data.resolved) ?? null;
+  let componentData = (data && data.resolved) ?? null;
+
+  if (overrides && componentData) {
+    const schema =
+      global.state.fileContents[component.paths?.schema?.full] ?? null;
+    componentData = applyOverrides(componentData, overrides, schema);
+  }
   const themeMode = getThemeMode(cookies);
 
   const validatedMocks = validateMocks(component, [
@@ -44,6 +52,16 @@ export default async function renderIframeVariation({
     standaloneUrl = `/component?file=${path.dirname(
       component.paths.tpl.short,
     )}&variation=${encodeURIComponent(variation)}`;
+
+    if (overrides && Object.keys(overrides).length > 0) {
+      const overrideParams = Object.entries(overrides)
+        .map(
+          ([k, v]) =>
+            `overrides[${encodeURIComponent(k)}]=${encodeURIComponent(v)}`,
+        )
+        .join("&");
+      standaloneUrl += `&${overrideParams}`;
+    }
   }
 
   const mockValidation = validatedMocks

--- a/lib/render/views/iframe/variation.standalone.js
+++ b/lib/render/views/iframe/variation.standalone.js
@@ -2,6 +2,7 @@ import path from "path";
 import config from "../../../default-config.js";
 import { getUserUiConfig } from "../../helpers.js";
 import resolveAssets from "../../helpers/resolve-assets.js";
+import applyOverrides from "../../helpers/apply-overrides.js";
 
 /**
  * @param {object} object - parameter object
@@ -20,7 +21,14 @@ export default async function renderIframeVariationStandalone({
   componentDeclaredAssets = null,
   cb,
   cookies,
+  overrides,
 }) {
+  if (overrides) {
+    const schema =
+      global.state.fileContents[component.paths?.schema?.full] ?? null;
+    componentData = applyOverrides(componentData ?? {}, overrides, schema);
+  }
+
   const directoryPath = component.paths.dir.short;
 
   return new Promise((resolve, reject) => {
@@ -49,6 +57,7 @@ export default async function renderIframeVariationStandalone({
             "component_variation.twig.miyagi",
             {
               html: result,
+              mockDataResolved: JSON.stringify(componentData ?? {}),
               cssFiles,
               jsFilesHead,
               jsFilesBody,

--- a/tests/lib/render/helpers/apply-overrides.test.js
+++ b/tests/lib/render/helpers/apply-overrides.test.js
@@ -1,0 +1,164 @@
+import { describe, test, expect } from "vitest";
+import applyOverrides from "../../../../lib/render/helpers/apply-overrides.js";
+
+describe("applyOverrides", () => {
+  describe("when overrides is null or undefined", () => {
+    test("returns data unchanged when overrides is null", () => {
+      const data = { color_scheme: "primary" };
+      expect(applyOverrides(data, null)).toBe(data);
+    });
+
+    test("returns data unchanged when overrides is undefined", () => {
+      const data = { color_scheme: "primary" };
+      expect(applyOverrides(data, undefined)).toBe(data);
+    });
+
+    test("returns data unchanged when overrides is not an object", () => {
+      const data = { color_scheme: "primary" };
+      expect(applyOverrides(data, "string")).toBe(data);
+    });
+  });
+
+  describe("string enum properties", () => {
+    test("overrides a string property with the provided value", () => {
+      const data = { color_scheme: "primary" };
+      const schema = {
+        properties: {
+          color_scheme: { type: "string", enum: ["primary", "secondary"] },
+        },
+      };
+      const result = applyOverrides(data, { color_scheme: "secondary" }, schema);
+      expect(result.color_scheme).toBe("secondary");
+    });
+
+    test("keeps other properties unchanged", () => {
+      const data = { color_scheme: "primary", label: "Click me" };
+      const schema = {
+        properties: {
+          color_scheme: { type: "string", enum: ["primary", "secondary"] },
+          label: { type: "string" },
+        },
+      };
+      const result = applyOverrides(
+        data,
+        { color_scheme: "secondary" },
+        schema,
+      );
+      expect(result.label).toBe("Click me");
+    });
+
+    test("returns a new object and does not mutate the original", () => {
+      const data = { color_scheme: "primary" };
+      const schema = {
+        properties: {
+          color_scheme: { type: "string", enum: ["primary", "secondary"] },
+        },
+      };
+      const result = applyOverrides(data, { color_scheme: "secondary" }, schema);
+      expect(result).not.toBe(data);
+      expect(data.color_scheme).toBe("primary");
+    });
+  });
+
+  describe("boolean properties", () => {
+    test('coerces "true" string to boolean true', () => {
+      const data = { disabled: false };
+      const schema = {
+        properties: { disabled: { type: "boolean" } },
+      };
+      const result = applyOverrides(data, { disabled: "true" }, schema);
+      expect(result.disabled).toBe(true);
+    });
+
+    test('coerces "false" string to boolean false', () => {
+      const data = { disabled: true };
+      const schema = {
+        properties: { disabled: { type: "boolean" } },
+      };
+      const result = applyOverrides(data, { disabled: "false" }, schema);
+      expect(result.disabled).toBe(false);
+    });
+
+    test("any non-\"true\" string coerces to false", () => {
+      const data = { disabled: true };
+      const schema = {
+        properties: { disabled: { type: "boolean" } },
+      };
+      const result = applyOverrides(data, { disabled: "yes" }, schema);
+      expect(result.disabled).toBe(false);
+    });
+  });
+
+  describe("numeric enum properties", () => {
+    test("coerces a string to a number when enum values are all numbers", () => {
+      const data = { columns: 1 };
+      const schema = {
+        properties: { columns: { enum: [1, 2, 3] } },
+      };
+      const result = applyOverrides(data, { columns: "2" }, schema);
+      expect(result.columns).toBe(2);
+      expect(typeof result.columns).toBe("number");
+    });
+
+    test("does not coerce to number when enum contains only strings", () => {
+      const data = { size: "md" };
+      const schema = {
+        properties: { size: { enum: ["sm", "md", "lg"] } },
+      };
+      const result = applyOverrides(data, { size: "lg" }, schema);
+      expect(result.size).toBe("lg");
+      expect(typeof result.size).toBe("string");
+    });
+
+    test("does not coerce to number when enum has mixed types", () => {
+      const data = { columns: "1" };
+      const schema = {
+        properties: { columns: { enum: [1, "two", 3] } },
+      };
+      const result = applyOverrides(data, { columns: "1" }, schema);
+      expect(result.columns).toBe("1");
+      expect(typeof result.columns).toBe("string");
+    });
+  });
+
+  describe("unknown properties", () => {
+    test("ignores properties not present in the schema", () => {
+      const data = { color_scheme: "primary" };
+      const schema = {
+        properties: {
+          color_scheme: { type: "string", enum: ["primary", "secondary"] },
+        },
+      };
+      const result = applyOverrides(
+        data,
+        { color_scheme: "secondary", unknown_prop: "value" },
+        schema,
+      );
+      expect(result).not.toHaveProperty("unknown_prop");
+    });
+  });
+
+  describe("when schema is missing or empty", () => {
+    test("returns data unchanged when schema is null", () => {
+      const data = { color_scheme: "primary" };
+      const result = applyOverrides(data, { color_scheme: "secondary" }, null);
+      expect(result).toEqual({ color_scheme: "primary" });
+    });
+
+    test("returns data unchanged when schema has no properties", () => {
+      const data = { color_scheme: "primary" };
+      const result = applyOverrides(
+        data,
+        { color_scheme: "secondary" },
+        { type: "object" },
+      );
+      expect(result).toEqual({ color_scheme: "primary" });
+    });
+
+    test("returns data unchanged when schema is undefined", () => {
+      const data = { color_scheme: "primary" };
+      const result = applyOverrides(data, { color_scheme: "secondary" });
+      expect(result).toEqual({ color_scheme: "primary" });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a live controls panel below the component iframe that reads `enum` and `boolean` schema properties, letting users interactively change values without maintaining near-identical mock variants. Re-renders are driven by `overrides[x]=y` query params applied server-side with schema-based type coercion.
- Injects resolved mock data as a `<script type="application/json" id="miyagi-mock-data">` data island in the standalone component iframe. `iframe.js` dispatches a `miyagi:mockdata` CustomEvent so web components can optionally access complex nested data structures — with zero Miyagi coupling required in production code.
- Controls panel supports docked (default) and floating layout modes, toggled by the user and persisted in `localStorage`. Controls API responses are cached in `sessionStorage` and invalidated via `postMessage` when schema or mock files change on disk.

## Changes

- `lib/render/helpers/apply-overrides.js` — new helper; merges override query params into resolved data with schema-based type coercion
- `lib/init/router.js` — new `GET /api/component-controls` endpoint; passes `overrides` through `/component` route
- `lib/render/views/iframe/variation.js` — applies overrides and propagates them to `standaloneUrl`
- `lib/render/views/iframe/variation.standalone.js` — applies overrides; passes `mockDataResolved` to template
- `frontend/views/component_variation.twig.miyagi` — injects mock data island
- `frontend/views/main.twig.miyagi` — adds controls panel DOM
- `frontend/assets/js/_controls.js` — new file; controls panel logic
- `frontend/assets/js/_main.js` — calls `loadControls()` on iframe navigation
- `frontend/assets/js/_socket.js` — posts `miyagi:invalidate-cache` message to parent on schema/data changes
- `frontend/assets/js/iframe.js` — dispatches `miyagi:mockdata` CustomEvent from data island
- `frontend/assets/css/main/controls.css` — new; controls panel styles (docked + floating modes)
- `frontend/assets/css/main.css` — imports controls CSS; flex layout for `.Content`/`.FrameWrapper`
- `frontend/assets/css/tokens.css` — adds z-index custom property scale
- `tests/lib/render/helpers/apply-overrides.test.js` — 16 tests for the override helper

## Test plan

- [ ] Component with `enum` schema property: controls panel appears with a dropdown; changing it re-renders the iframe with the new value reflected in HTML attributes
- [ ] Component with `boolean` schema property: checkbox appears; toggling re-renders correctly
- [ ] Component without schema or mocks: controls panel stays hidden
- [ ] Docked/floating toggle: clicking the mode button switches layout; preference survives page reload
- [ ] `sessionStorage` caching: navigating away and back produces no second network request to `/api/component-controls`
- [ ] Editing `schema.json` or `mocks.json` while Miyagi is running: WebSocket reload clears the cache and fetches fresh controls
- [ ] `miyagi:mockdata` CustomEvent fires in the component iframe with the correct resolved data (including active overrides) as `detail`
- [ ] `pnpm test` passes with no regressions

🤖 Generated with assistance from [Claude Code](https://claude.com/claude-code)