### PR TITLE
fix: repair live controls panel override application and mode-toggle label

### DIFF
--- a/frontend/assets/css/main/controls.css
+++ b/frontend/assets/css/main/controls.css
@@ -45,6 +45,14 @@
   padding: 0.25rem 0.5rem;
 }
 
+.Controls[data-mode="docked"] .Controls-modeToggle::before {
+  content: "Float";
+}
+
+.Controls[data-mode="floating"] .Controls-modeToggle::before {
+  content: "Dock";
+}
+
 .Controls-modeToggle:hover {
   color: var(--color-Text);
 }

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -29,6 +29,7 @@ export default async function init(mergedConfig) {
   global.app = express();
   global.app.use(cookieParser());
   global.config = mergedConfig;
+  global.app.set("query parser", "extended");
   global.app.set("view cache", global.config.isBuild);
   global.app.set("cache", global.config.isBuild);
 


### PR DESCRIPTION
## Summary

- **Controls not working**: Express 5 defaults to the `simple` query parser which treats `overrides[spacing]=xl` as a flat string key, leaving `req.query.overrides` as `undefined`. Set `query parser` to `"extended"` so bracket-notation params are parsed as nested objects and overrides are correctly applied.
- **Toggle button invisible**: The mode-toggle button had only a `u-hiddenVisually` span but no visible content. Added CSS `::before` labels — `"Float"` when docked, `"Dock"` when floating — so sighted users see what the button will do.

## Test plan

- [ ] Open a component variation that has `enum` or `boolean` schema properties
- [ ] Confirm the Controls panel appears with the correct dropdowns/checkboxes
- [ ] Change a dropdown value and confirm the component in the iframe updates accordingly
- [ ] Confirm the mode-toggle button shows "Float" when the panel is docked
- [ ] Click the toggle and confirm the panel floats and the button now shows "Dock"
- [ ] Click again and confirm it docks and the button shows "Float" again

🤖 Generated with [Claude Code](https://claude.com/claude-code)