### PR TITLE
feat: opt-in JSON data exposure via data.json

### DIFF
--- a/frontend/views/component_variation.twig.miyagi
+++ b/frontend/views/component_variation.twig.miyagi
@@ -24,8 +24,8 @@
     {% if assets.js %}
       <script src="{{ assets.js }}"></script>
     {% endif %}
-    {% if mockDataResolved is defined %}
-    <script type="application/json" id="miyagi-mock-data">{{ mockDataResolved|replace({'</script>': '<\\/script>'})|raw }}</script>
+    {% if dataJson is defined and dataJson %}
+    <script type="application/json" id="{{ dataJsonId }}">{{ dataJson|replace({'</script>': '<\\/script>'})|raw }}</script>
     {% endif %}
     <script>
       {{ theme.js }}

--- a/frontend/views/iframe_component.twig.miyagi
+++ b/frontend/views/iframe_component.twig.miyagi
@@ -34,6 +34,12 @@
 								<div id="json-tree-resolved-mocks" data-jsontree-js="jsontree.mocks"></div>
 							</details>
 						{% endif %}
+						{% if dataJson %}
+							<details class="Tabs-tab">
+								<summary>Data</summary>
+								<div id="json-tree-resolved-data" data-jsontree-js="jsontree.data"></div>
+							</details>
+						{% endif %}
 						{% if template %}
 							<details class="Tabs-tab">
 								<summary>Template</summary>
@@ -135,6 +141,9 @@
 				},
 				"mocks": {
 					"data": {{ mocks|default({})|replace({'</script>': '<\\/script>'})|raw }}
+				},
+				"data": {
+					"data": {{ dataJson|default({})|replace({'</script>': '<\\/script>'})|raw }}
 				}
 			};
 		</script>

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -665,6 +665,7 @@ export default () => {
             component,
             componentData: data.resolved,
             componentDeclaredAssets: data.$assets || null,
+            variation,
             cb: async (err, response) => {
               if (err) {
                 if (typeof err === "string") {

--- a/lib/data-json/index.js
+++ b/lib/data-json/index.js
@@ -1,0 +1,69 @@
+import { getVariationData, getComponentData } from "../mocks/index.js";
+import log from "../logger.js";
+
+/**
+ * Resolves the data.json content for a component.
+ *
+ * If no data.json exists, returns null values (no JSON exposed in DOM).
+ * If data.json has useMocks: true, uses the mocks pipeline as the data source.
+ * Otherwise, uses the data.json content directly (stripping the useMocks key).
+ * @param {object} component - the component route object
+ * @param {object} options
+ * @param {string} [options.variation] - the variation name (used when useMocks is true)
+ * @returns {Promise<{ json: string|null, id: string }>}
+ */
+export async function resolveDataJson(component, { variation } = {}) {
+  const dataJsonPath = component.paths.data.full;
+  const dataJsonContent = global.state.fileContents[dataJsonPath];
+
+  if (!dataJsonContent) {
+    return { json: null, id: "miyagi-mock-data" };
+  }
+
+  if (dataJsonContent.useMocks === true) {
+    return resolveFromMocks(component, variation);
+  }
+
+  return resolveFromDataJson(dataJsonContent);
+}
+
+/**
+ * Uses the mocks pipeline to produce the JSON content.
+ * @param {object} component
+ * @param {string} [variation]
+ * @returns {Promise<{ json: string|null, id: string }>}
+ */
+async function resolveFromMocks(component, variation) {
+  try {
+    let data;
+
+    if (variation) {
+      data = await getVariationData(component, variation);
+    } else {
+      const allData = await getComponentData(component);
+      data = allData?.[0] ?? null;
+    }
+
+    const resolved = data?.resolved ?? {};
+    return { json: JSON.stringify(resolved), id: "miyagi-mock-data" };
+  } catch (err) {
+    log(
+      "error",
+      `Error resolving mock data for data.json in ${component.paths.dir.short}`,
+      err,
+    );
+    return { json: null, id: "miyagi-mock-data" };
+  }
+}
+
+/**
+ * Uses the data.json content directly, stripping internal properties.
+ * @param {object} dataJsonContent - parsed data.json object
+ * @returns {{ json: string, id: string }}
+ */
+function resolveFromDataJson(dataJsonContent) {
+  const clone = structuredClone(dataJsonContent);
+  delete clone.useMocks;
+
+  return { json: JSON.stringify(clone), id: "miyagi-mock-data" };
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,4 +1,3 @@
-import v8 from "v8";
 import path from "path";
 
 /**
@@ -69,7 +68,7 @@ export const getResolvedFileName = function (nameInConfig, fileName) {
  * @returns {object} clone of rhe given object
  */
 export const cloneDeep = function (obj) {
-  return v8.deserialize(v8.serialize(obj));
+  return structuredClone(obj);
 };
 
 /**
@@ -131,6 +130,15 @@ export const fileIsSchemaFile = function (filePath) {
     path.basename(filePath) ===
     `${global.config.files.schema.name}.${global.config.files.schema.extension}`
   );
+};
+
+/**
+ * Accepts a file path and checks if it is a data.json file
+ * @param {string} filePath - path to any type of file
+ * @returns {boolean} is true if the given file is a data.json file
+ */
+export const fileIsDataJsonFile = function (filePath) {
+  return path.basename(filePath) === "data.json";
 };
 
 /**

--- a/lib/init/router.js
+++ b/lib/init/router.js
@@ -279,6 +279,7 @@ export default function Router() {
           componentDeclaredAssets: data?.$assets || null,
           cookies: req.cookies,
           overrides: overrides ?? null,
+          variation,
         });
       }
 

--- a/lib/init/watcher.js
+++ b/lib/init/watcher.js
@@ -298,6 +298,7 @@ async function updateFileContents(events) {
           fs.lstatSync(fullPath).isFile() &&
           (helpers.fileIsTemplateFile(relativePath) ||
             helpers.fileIsDataFile(relativePath) ||
+            helpers.fileIsDataJsonFile(relativePath) ||
             helpers.fileIsDocumentationFile(relativePath) ||
             helpers.fileIsSchemaFile(relativePath))
         ) {
@@ -356,6 +357,9 @@ async function handleFileChange(events) {
   );
   const schemaEvents = events.filter(({ relativePath }) =>
     helpers.fileIsSchemaFile(relativePath),
+  );
+  const dataJsonEvents = events.filter(({ relativePath }) =>
+    helpers.fileIsDataJsonFile(relativePath),
   );
   const componentAssetEvents = events.filter(({ relativePath }) =>
     helpers.fileIsAssetFile(relativePath),
@@ -527,6 +531,19 @@ async function handleFileChange(events) {
     sendReload(watchRules.schema, {
       reason: "schema",
       paths: schemaEvents.map(({ relativePath }) => relativePath),
+    });
+    log("success", `${t("updatingDone")}\n`);
+    return;
+  }
+
+  if (dataJsonEvents.length > 0) {
+    await setState({
+      fileContents: await updateFileContents(dataJsonEvents),
+    });
+
+    sendReload(watchRules.data, {
+      reason: "data-json",
+      paths: dataJsonEvents.map(({ relativePath }) => relativePath),
     });
     log("success", `${t("updatingDone")}\n`);
     return;

--- a/lib/render/views/iframe/component.js
+++ b/lib/render/views/iframe/component.js
@@ -32,6 +32,8 @@ export default async function renderIframeComponent({
     global.state.fileContents[path.join(component.paths.dir.full, "README.md")];
   const componentSchema =
     global.state.fileContents[component.paths.schema.full];
+  const componentDataJson =
+    global.state.fileContents[component.paths.data.full] ?? null;
   const componentTemplate = hasTemplate
     ? global.state.fileContents[component.paths.tpl.full]
     : null;
@@ -100,6 +102,16 @@ export default async function renderIframeComponent({
           file: path.join(
             global.config.components.folder,
             helpers.getShortPathFromFullPath(component.paths.tpl.full),
+          ),
+        }
+      : null,
+    data: componentDataJson
+      ? {
+          string: JSON.stringify(componentDataJson, null, 2),
+          type: "json",
+          file: path.join(
+            global.config.components.folder,
+            component.paths.data.short,
           ),
         }
       : null,
@@ -205,13 +217,24 @@ async function renderVariations({
     }
   }
 
+  let dataJson;
+
+  if (fileContents?.data?.string) {
+    try {
+      dataJson = JSON.stringify(JSON.parse(fileContents.data.string));
+    } catch (err) {
+      log("error", null, err);
+    }
+  }
+
   return Promise.all(promises)
     .then(async () => {
       const themeMode = getThemeMode(cookies);
       const renderFileTabs = !!(
         fileContents.schema ||
         fileContents.mocks ||
-        fileContents.template
+        fileContents.template ||
+        fileContents.data
       );
       const componentsEntry = global.state.components.find(
         ({ shortPath }) => shortPath === component.paths.dir.short,
@@ -259,6 +282,7 @@ async function renderVariations({
               ? validatedMocks[0].data.map((error) => error.message).join("\n")
               : null,
           mocks: mocksJson,
+          dataJson,
           template: fileContents.template,
           renderInformation: renderFileTabs || variations.length > 0,
           renderFileTabs,

--- a/lib/render/views/iframe/variation.standalone.js
+++ b/lib/render/views/iframe/variation.standalone.js
@@ -1,5 +1,6 @@
 import path from "path";
 import config from "../../../default-config.js";
+import { resolveDataJson } from "../../../data-json/index.js";
 import { getUserUiConfig } from "../../helpers.js";
 import resolveAssets from "../../helpers/resolve-assets.js";
 import applyOverrides from "../../helpers/apply-overrides.js";
@@ -13,6 +14,7 @@ import applyOverrides from "../../helpers/apply-overrides.js";
  * @param {Function} [object.cb] - callback function
  * @param {object} [object.cookies]
  * @param {object} [object.overrides] - query-param override values
+ * @param {string} [object.variation] - the variation name
  * @returns {Promise} gets resolved when the variation has been rendered
  */
 export default async function renderIframeVariationStandalone({
@@ -23,6 +25,7 @@ export default async function renderIframeVariationStandalone({
   cb,
   cookies,
   overrides,
+  variation,
 }) {
   if (overrides) {
     const schema =
@@ -31,6 +34,9 @@ export default async function renderIframeVariationStandalone({
   }
 
   const directoryPath = component.paths.dir.short;
+  const { json: dataJson, id: dataJsonId } = await resolveDataJson(component, {
+    variation,
+  });
 
   return new Promise((resolve, reject) => {
     global.app.render(
@@ -58,7 +64,8 @@ export default async function renderIframeVariationStandalone({
             "component_variation.twig.miyagi",
             {
               html: result,
-              mockDataResolved: JSON.stringify(componentData ?? {}),
+              dataJson,
+              dataJsonId,
               cssFiles,
               jsFilesHead,
               jsFilesBody,

--- a/lib/state/components.js
+++ b/lib/state/components.js
@@ -116,6 +116,10 @@ function addToRoutes({ name, shortPath, fullPath }, partials = []) {
           full: path.join(fullPath, "README.md"),
           short: path.join(shortPath, "README.md"),
         },
+        data: {
+          full: path.join(fullPath, "data.json"),
+          short: path.join(shortPath, "data.json"),
+        },
       },
       type: "components",
     };

--- a/lib/state/file-contents.js
+++ b/lib/state/file-contents.js
@@ -69,6 +69,7 @@ async function getFilePaths(sourceTree) {
               `${files.mocks.name}.${files.mocks.extension[0]}`,
               `${files.mocks.name}.${files.mocks.extension[1]}`,
               `${files.schema.name}.${files.schema.extension}`,
+              "data.json",
             ]) ||
             helpers.fileIsDocumentationFile(entry.path)
           ) {

--- a/starlight/astro.config.mjs
+++ b/starlight/astro.config.mjs
@@ -47,6 +47,7 @@ export default defineConfig({
             { label: "Schema", slug: "component-files/schema" },
             { label: "Documentation", slug: "component-files/documentation" },
             { label: "Assets", slug: "component-files/assets" },
+            { label: "Data", slug: "component-files/data" },
           ],
         },
         {
@@ -135,6 +136,10 @@ export default defineConfig({
             {
               label: "Creating a design token overview",
               slug: "how-to/creating-a-design-token-overview",
+            },
+            {
+              label: "Exposing JSON data to components",
+              slug: "how-to/exposing-json-data-to-components",
             },
             {
               label: "Linting mock data",

--- a/starlight/src/content/docs/component-files/data.md
+++ b/starlight/src/content/docs/component-files/data.md
@@ -1,0 +1,58 @@
+---
+title: "Data"
+---
+
+**File:** `data.json`
+
+The `data.json` file lets you opt in to exposing JSON data to your component's JavaScript via a `<script type="application/json">` tag in the DOM. By default, no JSON is exposed — you must create a `data.json` file in your component folder to enable this.
+
+## How it works
+
+When _miyagi_ finds a `data.json` file in a component folder, it injects a `<script type="application/json" id="miyagi-mock-data">` tag into the component's rendered HTML. Your component's JavaScript can then read and parse this data.
+
+The data is only exposed when the component is the **primary subject** of the view — that is, when you are viewing the component directly (overview, specific variation, or standalone page). If the component is included as a partial within a larger template or component, its `data.json` is not used.
+
+## Using custom JSON
+
+The simplest use case: the content of `data.json` is the JSON you want to expose.
+
+```json
+{
+  "apiEndpoint": "/api/search",
+  "maxResults": 10,
+  "locale": "en-US"
+}
+```
+
+This JSON will be available in the DOM exactly as written.
+
+## Using mock data as the source
+
+If your component's JavaScript needs the same data that drives the template, set `useMocks` to `true`:
+
+```json
+{
+  "useMocks": true
+}
+```
+
+When `useMocks` is `true`, _miyagi_ runs the component's mock data through its full resolution pipeline (including `$ref` resolution, `$tpl` rendering, and global data merging) and exposes the resolved result. When viewing a specific variation, the variation's resolved data is used.
+
+The `useMocks` property is always stripped from the exposed JSON.
+
+## Reading the data in JavaScript
+
+```js
+const scriptTag = document.getElementById("miyagi-mock-data");
+
+if (scriptTag) {
+  const data = JSON.parse(scriptTag.textContent);
+  // Use data...
+}
+```
+
+## Viewing data.json in the UI
+
+When a component has a `data.json` file, its content is shown in the **Files** section of the component overview page, alongside the schema, mocks, and template tabs.
+
+Please refer to "[Exposing JSON data to components](/how-to/exposing-json-data-to-components/)" for a practical guide on when and how to use this feature.

--- a/starlight/src/content/docs/how-to/exposing-json-data-to-components.md
+++ b/starlight/src/content/docs/how-to/exposing-json-data-to-components.md
@@ -1,0 +1,74 @@
+---
+title: "Exposing JSON data to components"
+---
+
+Some components need JSON data available to their JavaScript at runtime — configuration, state, or the same data that drives the template. The `data.json` file lets you opt in to this on a per-component basis.
+
+## When to use `useMocks: true`
+
+Use this when your component's JavaScript needs the **same data that the template receives**. For example, a chart component where the template renders labels and headings, but JavaScript draws the chart using the full dataset.
+
+Create a `data.json` in the component folder:
+
+```json
+{
+  "useMocks": true
+}
+```
+
+_miyagi_ will resolve the component's mock data through its full pipeline (including `$ref` and `$tpl` resolution) and expose the result as JSON in the DOM. When viewing a specific variation, the variation's resolved data is used.
+
+## When to use custom JSON
+
+Use this when your component needs data that **doesn't map to mock data** — API endpoints, feature flags, i18n strings for JavaScript, or any bespoke configuration.
+
+Create a `data.json` with the data you want to expose:
+
+```json
+{
+  "apiEndpoint": "/api/suggestions",
+  "debounceMs": 300,
+  "minQueryLength": 3
+}
+```
+
+This JSON is exposed as-is (the `useMocks` key is stripped if present, but no other processing is applied).
+
+## Reading the data
+
+The JSON is injected as a `<script type="application/json" id="miyagi-mock-data">` tag in the `<head>` of the component's rendered HTML. Read it in your component's JavaScript:
+
+```js
+const el = document.getElementById("miyagi-mock-data");
+
+if (el) {
+  const config = JSON.parse(el.textContent);
+  initAutocomplete(config);
+}
+```
+
+## When data is exposed
+
+The JSON is only exposed when the component is the **primary subject** of the view:
+
+- Viewing the component overview page
+- Viewing a specific variation
+- Opening the component in a new tab (standalone page)
+
+When the component is included as a partial within a larger template or another component, its `data.json` is **not** consulted. This keeps the feature predictable and avoids unintended side effects in composed views.
+
+## Component folder structure
+
+A component using `data.json` might look like this:
+
+```
+button/
+  index.twig
+  mocks.json
+  schema.json
+  data.json        ← opt-in JSON exposure
+  index.css
+  index.js
+```
+
+The `data.json` file is completely optional. Components without it behave exactly as before — no JSON is exposed in the DOM.

--- a/starlight/src/content/docs/how-to/writing-mock-data.md
+++ b/starlight/src/content/docs/how-to/writing-mock-data.md
@@ -333,3 +333,7 @@ To force **all** components into isolated mode (even those without `$assets`), s
 You can define global mock data by creating a `mocks.json` (or whatever you defined the mock files to be named like in `files.mocks`) in your [`components.folder`](/configuration/options#components). This mock data will be merged into your components mock data. The components mock data has higher priority, hence overwrites keys with the same name.
 
 You can also add definitions (see above) to the global mock data. When referencing them, you can do this with `mocks/#/$defs/…`. `mocks` needs to be replaced with whatever you defined in `files.mocks.name`.
+
+## Exposing data to JavaScript
+
+If your component's JavaScript needs access to mock data or custom JSON in the DOM, see "[Exposing JSON data to components](/how-to/exposing-json-data-to-components/)".

--- a/starlight/src/content/docs/the-ui.md
+++ b/starlight/src/content/docs/the-ui.md
@@ -14,7 +14,7 @@ The _component_ page renders
 
 - the content of the component's [documentation file](/component-files/documentation),
 - an info section including the actual component path,
-- the component's [schema](/component-files/schema), [mock data](/component-files/mocks) and [template](/component-files/template),
+- the component's [schema](/component-files/schema), [mock data](/component-files/mocks), [data](/component-files/data) and [template](/component-files/template),
 - all variants including the validation status of the mock file as well as the compiled mock data.
 
 ## Component variation


### PR DESCRIPTION
## Summary

- Components can now opt in to exposing JSON data in the DOM by adding a `data.json` file to their component folder
- Without `data.json`, no JSON is exposed (replaces the previous always-on mock data injection)
- Two modes: custom JSON (file content exposed directly) or mock pipeline (`useMocks: true` to expose resolved mock data)
- Data is only exposed when the component is the primary subject of the view, not when included as a partial
- Adds a "Data" tab to the Files section in the component overview UI
- Replaces `v8.serialize`/`v8.deserialize` with `structuredClone` throughout
- Includes new documentation: component file reference and how-to guide

## Test plan

- [ ] Create a test component with no `data.json` — verify no `<script type="application/json">` appears
- [ ] Create a test component with `data.json` containing `{ "useMocks": true }` — verify mocks data appears in DOM
- [ ] Create a test component with `data.json` containing custom JSON — verify it appears without `useMocks` key
- [ ] View a template that includes a component with `data.json` — verify JSON does NOT appear
- [ ] Verify "Data" tab appears in the Files section alongside Schema, Mocks, Template
- [ ] Modify `data.json` while dev server is running — verify live reload
- [ ] Run `pnpm test` (194 tests pass)
- [ ] Run `pnpm lint` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)