### PR TITLE
feat: add performance budget tracking

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -17,6 +17,8 @@ import {
   validateComponentHtml as validateComponentHtmlImpl,
 } from "../lib/validator/html.js";
 import { generateMarkdownReport } from "../lib/validator/html-report.js";
+import { runPerformance } from "../lib/performance/index.js";
+import { generatePerformanceReport } from "../lib/performance/report.js";
 
 /**
  * @param {object} obj
@@ -324,6 +326,39 @@ export const validateHtml = async (options = {}) => {
   return {
     success: results.summary.failed === 0,
     data: { results, report },
+  };
+};
+
+/**
+ * Run the performance-budget check programmatically.
+ * @param {object} [options]
+ * @param {boolean} [options.html] - include post-build HTML pages
+ * @param {string} [options.buildFolder] - required when html is true
+ * @param {"raw"|"gzip"|"brotli"} [options.compression] - override config compression
+ * @returns {Promise<object>}
+ */
+export const getPerformance = async (options = {}) => {
+  global.app = await init("api");
+
+  if (options.compression) {
+    global.config.performance = {
+      ...(global.config.performance || {}),
+      compression: options.compression,
+    };
+  }
+
+  const result = runPerformance({
+    config: global.config,
+    html: Boolean(options.html),
+    buildFolder: options.buildFolder,
+  });
+
+  return {
+    success: result.summary.exceed === 0,
+    data: {
+      result,
+      report: generatePerformanceReport(result),
+    },
   };
 };
 

--- a/frontend/assets/css/iframe.css
+++ b/frontend/assets/css/iframe.css
@@ -4,6 +4,7 @@
 @import url("./iframe/accordion-tabs.css") layer(miyagi);
 @import url("./iframe/jsontree.js.css") layer(miyagi);
 @import url("./iframe/styleguide/index.css") layer(miyagi);
+@import url("./iframe/performance.css") layer(miyagi);
 
 html {
   --iframe-spacing: clamp(0.75rem, 4vi, 2.5rem);

--- a/frontend/assets/css/iframe/performance.css
+++ b/frontend/assets/css/iframe/performance.css
@@ -1,0 +1,64 @@
+.PerformanceTable {
+  border-collapse: collapse;
+  margin-block: 1em;
+  width: 100%;
+}
+
+.PerformanceTable :is(th, td) {
+  padding: 0.35em 0.75em;
+  text-align: start;
+  vertical-align: top;
+}
+
+.PerformanceTable thead th {
+  border-block-end: 0.0625rem solid currentcolor;
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 0.875em;
+  letter-spacing: 0.0375em;
+}
+
+.PerformanceTable tbody tr:not(:last-child) :is(td, th) {
+  border-block-end: 0.0625rem solid var(--color-Outline);
+}
+
+.PerformanceTable-totals :is(th, td) {
+  font-weight: bold;
+}
+
+.PerformanceTable tr[data-missing="true"] td {
+  color: var(--color-Iframe-text-secondary);
+}
+
+.PerformanceStatus {
+  display: inline-block;
+  padding: 0.15em 0.6em;
+  border-radius: 0.25em;
+  font-size: 0.875em;
+  font-weight: bold;
+  letter-spacing: 0.0375em;
+  text-transform: uppercase;
+}
+
+.PerformanceStatus--ok {
+  background: color-mix(in srgb, var(--color-Positive) 20%, transparent);
+  color: var(--color-Positive);
+}
+
+.PerformanceStatus--warn {
+  background: color-mix(
+    in srgb,
+    var(--color-Iframe-text-secondary) 25%,
+    transparent
+  );
+  color: var(--color-Iframe-text);
+}
+
+.PerformanceStatus--exceed {
+  background: color-mix(in srgb, var(--color-Negative) 20%, transparent);
+  color: var(--color-Negative);
+}
+
+.PerformanceStatus--unbudgeted {
+  color: var(--color-Iframe-text-secondary);
+}

--- a/frontend/views/performance.twig.miyagi
+++ b/frontend/views/performance.twig.miyagi
@@ -1,0 +1,72 @@
+{% extends "@miyagi/layouts/iframe_default.twig.miyagi" %}
+{% block body %}
+	<div class="Wrapper">
+		<div class="Documentation">
+			<h1>Performance budget</h1>
+			<p>Measured at <strong>{{ compression }}</strong>. OK: {{ summary.ok }} · Warn: {{ summary.warn }} · Exceed: {{ summary.exceed }} · Unbudgeted: {{ summary.unbudgeted }}.</p>
+
+			<h2>Evaluations</h2>
+			<table class="PerformanceTable">
+				<thead>
+					<tr>
+						<th scope="col">Category</th>
+						<th scope="col">Item</th>
+						<th scope="col">Actual</th>
+						<th scope="col">Budget</th>
+						<th scope="col">Status</th>
+					</tr>
+				</thead>
+				<tbody>
+					{% for row in evaluations %}
+						<tr data-status="{{ row.status }}">
+							<td>{{ row.category }}</td>
+							<td>{% if row.key == "total" %}Total{% else %}{{ row.label }}{% endif %}</td>
+							<td>{{ row.actualFormatted }}</td>
+							<td>{{ row.budgetFormatted }}</td>
+							<td>
+								<span class="PerformanceStatus PerformanceStatus--{{ row.status }}">
+									{% if row.status == "ok" %}OK{% elseif row.status == "warn" %}WARN{% elseif row.status == "exceed" %}EXCEED{% else %}—{% endif %}
+								</span>
+								{% if row.ratioPercent is not null %}
+									<small>({{ row.ratioPercent }}%)</small>
+								{% endif %}
+							</td>
+						</tr>
+					{% endfor %}
+				</tbody>
+			</table>
+
+			{% for cat in categories %}
+				{% if cat.files|length > 0 %}
+					<h2>{{ cat.category }}</h2>
+					<table class="PerformanceTable">
+						<thead>
+							<tr>
+								<th scope="col">File</th>
+								<th scope="col">Raw</th>
+								<th scope="col">Gzip</th>
+								<th scope="col">Brotli</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for file in cat.files %}
+								<tr{% if file.missing %} data-missing="true"{% endif %}>
+									<td>{{ file.path }}{% if file.missing %} <em>(missing)</em>{% endif %}</td>
+									<td>{{ file.raw }}</td>
+									<td>{{ file.gzip }}</td>
+									<td>{{ file.brotli }}</td>
+								</tr>
+							{% endfor %}
+							<tr class="PerformanceTable-totals">
+								<th scope="row">Total</th>
+								<td>{{ cat.totals.raw }}</td>
+								<td>{{ cat.totals.gzip }}</td>
+								<td>{{ cat.totals.brotli }}</td>
+							</tr>
+						</tbody>
+					</table>
+				{% endif %}
+			{% endfor %}
+		</div>
+	</div>
+{% endblock %}

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -7,6 +7,8 @@ import appConfig from "../default-config.js";
 import { t } from "../i18n/index.js";
 import log from "../logger.js";
 import { getVariationData } from "../mocks/index.js";
+import { runPerformance } from "../performance/index.js";
+import { generatePerformanceReport } from "../performance/report.js";
 
 /**
  * Module for creating a static build
@@ -176,6 +178,12 @@ export default () => {
           .then(async () => {
             await createJsonOutputFile(buildFolder, paths);
 
+            const performanceError = await writePerformanceReport(buildFolder);
+            if (performanceError) {
+              reject(performanceError);
+              return;
+            }
+
             resolve(
               t("buildDone").replace(
                 "{{count}}",
@@ -189,6 +197,71 @@ export default () => {
       });
     });
   });
+
+  /**
+   * Runs the performance-budget check against the just-built output, logs a
+   * summary, and (when configured) writes a markdown report. Never throws —
+   * a missing budget configuration is treated as "feature disabled". The only
+   * way this returns an Error is when `performance.report.failOnExceed` is on
+   * and a budget has actually been exceeded.
+   * @param {string} buildFolder
+   * @returns {Promise<Error|null>}
+   */
+  async function writePerformanceReport(buildFolder) {
+    const perfConfig = global.config.performance;
+    if (!perfConfig || !perfConfig.enabled) {
+      return null;
+    }
+
+    let result;
+    try {
+      result = runPerformance({
+        config: global.config,
+        html: true,
+        buildFolder,
+      });
+    } catch (error) {
+      log("warn", `Performance budget check skipped: ${error.message}`);
+      return null;
+    }
+
+    const configuredOutput = perfConfig.report?.output;
+    if (configuredOutput) {
+      // A bare filename (no directory component) lands inside the build folder
+      // alongside output.json; anything with a directory is honoured as-is.
+      const outputPath =
+        path.dirname(configuredOutput) === "."
+          ? path.join(buildFolder, configuredOutput)
+          : path.resolve(configuredOutput);
+
+      try {
+        await writeFile(
+          outputPath,
+          generatePerformanceReport(result),
+          "utf-8",
+        );
+        log("info", null, `Wrote ${outputPath}.`);
+      } catch (error) {
+        log("warn", `Failed to write performance report: ${error.message}`);
+      }
+    }
+
+    const { exceed, warn, ok, unbudgeted } = result.summary;
+    const summaryLine = `Performance budget (${result.compression}): ${ok} ok, ${warn} warn, ${exceed} exceed, ${unbudgeted} unbudgeted.`;
+
+    if (exceed > 0) {
+      log("warn", summaryLine);
+      if (perfConfig.report?.failOnExceed) {
+        return new Error(
+          `Performance budget exceeded in ${exceed} categor${exceed === 1 ? "y" : "ies"}.`,
+        );
+      }
+    } else {
+      log("info", summaryLine);
+    }
+
+    return null;
+  }
 
   /**
    * Creates an "output.json" file with the given array as content

--- a/lib/cli/budget.js
+++ b/lib/cli/budget.js
@@ -1,0 +1,157 @@
+import { writeFile } from "node:fs/promises";
+import getConfig from "../config.js";
+import log from "../logger.js";
+import { EXIT_CODES } from "../errors.js";
+import { runPerformance } from "../performance/index.js";
+import { generatePerformanceReport } from "../performance/report.js";
+import { formatSize } from "../performance/parse-size.js";
+
+const VALID_COMPRESSIONS = ["raw", "gzip", "brotli"];
+
+/**
+ * `miyagi budget` — on-demand performance budget check.
+ * By default walks the configured global CSS/JS and asset folders, measures
+ * them, and compares against `config.performance.budgets`. The HTML category
+ * (post-build pages) is opt-in via `--build-folder`.
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+export default async function budgetCli(args) {
+  const config = await getConfig(args);
+  global.config = config;
+
+  if (args.compression && !VALID_COMPRESSIONS.includes(args.compression)) {
+    log(
+      "error",
+      `Unknown --compression "${args.compression}". Use one of: ${VALID_COMPRESSIONS.join(", ")}`,
+    );
+    return {
+      success: false,
+      code: EXIT_CODES.CLI_USAGE_ERROR,
+      shouldExit: true,
+    };
+  }
+
+  if (args.compression) {
+    config.performance = {
+      ...(config.performance || {}),
+      compression: args.compression,
+    };
+  }
+
+  const result = runPerformance({
+    config,
+    html: Boolean(args.buildFolder),
+    buildFolder: args.buildFolder,
+    listAllPages: args.listAllPages,
+  });
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  } else {
+    printTable(result);
+  }
+
+  if (args.output) {
+    const report = generatePerformanceReport(result);
+    try {
+      await writeFile(args.output, report, "utf-8");
+      log("info", `Performance report written to ${args.output}`);
+    } catch (error) {
+      log("error", `Failed to write report: ${error.message}`);
+    }
+  }
+
+  const exceeded = result.summary.exceed > 0;
+  const shouldFail =
+    args.fail || config.performance?.report?.failOnExceed;
+
+  if (exceeded && shouldFail) {
+    return {
+      success: false,
+      code: EXIT_CODES.VALIDATION_ERROR,
+      shouldExit: true,
+    };
+  }
+
+  if (exceeded) {
+    log(
+      "warn",
+      `Performance budget exceeded in ${result.summary.exceed} categor${result.summary.exceed === 1 ? "y" : "ies"}.`,
+    );
+  }
+
+  return {
+    success: true,
+    code: EXIT_CODES.SUCCESS,
+    shouldExit: true,
+  };
+}
+
+/**
+ * @param {import("../performance/index.js").PerformanceResult} result
+ * @returns {void}
+ */
+function printTable(result) {
+  const { evaluations, compression, summary } = result;
+
+  log("info", `Performance budget — measured at ${compression}.`);
+
+  const header = ["Category", "Item", "Actual", "Budget", "Status"];
+  const rows = evaluations.map((row) => [
+    row.category,
+    row.key === "total" ? "Total" : shortLabel(row.label),
+    formatSize(row.actual),
+    formatSize(row.budget),
+    statusLabel(row.status),
+  ]);
+
+  const columnWidths = header.map((heading, index) =>
+    Math.max(heading.length, ...rows.map((row) => row[index].length)),
+  );
+
+  const padCell = (text, width) => text + " ".repeat(width - text.length);
+  const renderRow = (columns) =>
+    columns.map((cell, index) => padCell(cell, columnWidths[index])).join("  ");
+
+  process.stdout.write(`${renderRow(header)}\n`);
+  process.stdout.write(
+    `${columnWidths.map((width) => "-".repeat(width)).join("  ")}\n`,
+  );
+  for (const row of rows) {
+    process.stdout.write(`${renderRow(row)}\n`);
+  }
+  process.stdout.write(
+    `\nOK: ${summary.ok}  Warn: ${summary.warn}  Exceed: ${summary.exceed}  Unbudgeted: ${summary.unbudgeted}\n`,
+  );
+}
+
+const MAX_LABEL_LENGTH = 60;
+
+/**
+ * @param {string} label
+ * @returns {string}
+ */
+function shortLabel(label) {
+  if (label.length <= MAX_LABEL_LENGTH) {
+    return label;
+  }
+  return `…${label.slice(-(MAX_LABEL_LENGTH - 1))}`;
+}
+
+/**
+ * @param {string} status
+ * @returns {string}
+ */
+function statusLabel(status) {
+  switch (status) {
+    case "ok":
+      return "OK";
+    case "warn":
+      return "WARN";
+    case "exceed":
+      return "EXCEED";
+    default:
+      return "—";
+  }
+}

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -3,9 +3,11 @@ import componentImport from "./component.js";
 import drupalAssetsImport from "./drupal-assets.js";
 import doctorImport from "./doctor.js";
 import validateHtmlImport from "./validate-html.js";
+import budgetImport from "./budget.js";
 
 export const lint = lintImport;
 export const component = componentImport;
 export const drupalAssets = drupalAssetsImport;
 export const doctor = doctorImport;
 export const validateHtml = validateHtmlImport;
+export const budgetCli = budgetImport;

--- a/lib/cli/run.js
+++ b/lib/cli/run.js
@@ -10,6 +10,7 @@ import {
   drupalAssets,
   doctor,
   validateHtml as validateHtmlCli,
+  budgetCli,
 } from "./index.js";
 import { EXIT_CODES, MiyagiError } from "../errors.js";
 
@@ -236,6 +237,15 @@ async function runDoctorCommand(args) {
 }
 
 /**
+ * @param {object} args
+ * @returns {Promise<object>}
+ */
+async function runBudgetCommand(args) {
+  applyCliEnv(args);
+  return await budgetCli(args);
+}
+
+/**
  * @param {Error|MiyagiError|string} error
  * @param {string[]} argv
  * @returns {object}
@@ -281,6 +291,7 @@ export async function runCli(argv = process.argv) {
       validateHtml: runValidateHtmlCommand,
       drupalAssets: runDrupalAssetsCommand,
       doctor: runDoctorCommand,
+      budget: runBudgetCommand,
     },
     argv,
   );

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -89,6 +89,39 @@ export default {
       },
     },
     namespaces: {},
+    // Performance budget feature — tracks asset byte size against configured
+    // limits and surfaces the state via `miyagi budget`, the build-time report,
+    // and the dev-server UI. Defaults mirror the "Slow 4G / Moto G4" tier from
+    // web.dev's "Your First Performance Budget" (see docs).
+    performance: {
+      enabled: true,
+      compression: "gzip",
+      report: {
+        failOnExceed: false,
+        output: "performance-report.md",
+      },
+      budgets: {
+        global: {
+          css: "35 kB",
+          js: "200 kB",
+          total: null,
+        },
+        html: {
+          perPage: "30 kB",
+          total: null,
+        },
+        folders: {
+          fonts: { total: "30 kB" },
+          images: { total: "50 kB" },
+          total: null,
+        },
+        perComponent: {
+          css: null,
+          js: null,
+          total: null,
+        },
+      },
+    },
     projectName: "miyagi",
     ui: {
       mode: "light",

--- a/lib/init/args.js
+++ b/lib/init/args.js
@@ -168,6 +168,45 @@ export default function createCli(handlers, argv = process.argv) {
       () => {},
       commandHandler(handlers.doctor),
     )
+    .command(
+      "budget",
+      "Checks asset byte sizes against your performance budget",
+      (builder) =>
+        builder
+          .option("compression", {
+            description: "Which compression to compare against the budget",
+            type: "string",
+            choices: ["raw", "gzip", "brotli"],
+          })
+          .option("fail", {
+            description: "Exit with a non-zero code if any budget is exceeded",
+            type: "boolean",
+            default: false,
+          })
+          .option("json", {
+            description:
+              "Emit the full evaluation as JSON on stdout (for CI / automation)",
+            type: "boolean",
+            default: false,
+          })
+          .option("output", {
+            alias: "o",
+            description: "Also write a markdown report to this path",
+            type: "string",
+          })
+          .option("build-folder", {
+            description:
+              "Include post-build HTML pages from this folder (reads output.json)",
+            type: "string",
+          })
+          .option("list-all-pages", {
+            description:
+              "List every HTML page in the evaluation, not just those that exceed or warn",
+            type: "boolean",
+            default: false,
+          }),
+      commandHandler(handlers.budget),
+    )
     .help()
     .version(pkgJson.version)
     .alias("help", "h")

--- a/lib/init/router.js
+++ b/lib/init/router.js
@@ -8,6 +8,7 @@ import config from "../default-config.js";
 import render from "../render/index.js";
 import { getVariationData } from "../mocks/index.js";
 import log from "../logger.js";
+import { runPerformance } from "../performance/index.js";
 
 /**
  * @param {object} component
@@ -101,6 +102,32 @@ export default function Router() {
       cookies: req.cookies,
     });
   });
+
+  // Performance budget — dev-mode only.
+  if (!global.config.isBuild && global.config.performance?.enabled) {
+    global.app.get("/performance", async (req, res) => {
+      return render.renderMainPerformance({
+        res,
+        cookies: req.cookies,
+      });
+    });
+
+    global.app.get("/iframe/performance", async (req, res) => {
+      return render.iframe.performance({
+        res,
+        cookies: req.cookies,
+      });
+    });
+
+    global.app.get("/api/performance", (req, res) => {
+      try {
+        const result = runPerformance({ config: global.config });
+        res.json(result);
+      } catch (error) {
+        res.status(500).json({ error: error.message });
+      }
+    });
+  }
 
   global.app.get("/show", async (req, res) => {
     const { file, variation } = req.query;

--- a/lib/performance/index.js
+++ b/lib/performance/index.js
@@ -1,0 +1,400 @@
+/**
+ * Performance-budget orchestrator.
+ * Turns the Miyagi config + filesystem state into a set of measurements and
+ * evaluations against the configured budgets. The output shape is shared by the
+ * CLI, the markdown report, and the dev-UI panel so each consumer renders the
+ * same data differently rather than re-deriving it.
+ * @module performance
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { measure } from "./measure.js";
+import parseSize from "./parse-size.js";
+
+/**
+ * @typedef {object} EvaluationRow
+ * @property {string} category - "global-css" | "global-js" | "folder:<name>" | "html"
+ * @property {string} key - stable identifier inside the category ("total", "perPage", or a file path)
+ * @property {string} label - human-readable label
+ * @property {number} actual - measured bytes (at the configured compression)
+ * @property {number|null} budget - configured budget in bytes, or null if unset
+ * @property {"ok"|"warn"|"exceed"|"unbudgeted"} status - classification against budget
+ * @property {number|null} ratio - actual / budget when budget is set
+ */
+
+/**
+ * @typedef {object} PerformanceResult
+ * @property {import("./measure.js").Measurement} measurement - raw per-file and per-category bytes
+ * @property {EvaluationRow[]} evaluations - budget comparison rows
+ * @property {"raw"|"gzip"|"brotli"} compression - which metric evaluations use
+ * @property {{ok: number, warn: number, exceed: number, unbudgeted: number}} summary - counts per status
+ */
+
+const WARN_RATIO = 0.8;
+
+/**
+ * Expand a css-string or js-object asset entry to a filesystem path.
+ * @param {string|{src: string}} entry
+ * @param {string} root
+ * @returns {string|null} absolute path, or null if the entry points at a remote URL
+ */
+function resolveAssetPath(entry, root) {
+  const rel = typeof entry === "string" ? entry : entry?.src;
+
+  if (!rel || URL.canParse(rel)) {
+    return null;
+  }
+
+  return path.resolve(root || "", rel);
+}
+
+/**
+ * Walk a directory, collecting absolute paths of all non-directory entries.
+ * Hidden files (starting with a dot) are skipped — they are almost never shipped.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function walkFolder(dir) {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true, recursive: true });
+  const files = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (entry.name.startsWith(".")) {
+      continue;
+    }
+
+    // entry.parentPath on Node 20+ gives the containing directory as an absolute
+    // path when `dir` was absolute — which it always is at our call sites.
+    files.push(path.join(entry.parentPath, entry.name));
+  }
+
+  return files;
+}
+
+/**
+ * Build the list of categorised file sets for the "always-on" (dev + CLI) scope:
+ * global CSS, global JS, and each configured asset folder.
+ * @param {object} config - global.config (or a spy equivalent in tests)
+ * @returns {{category: string, label: string, files: string[]}[]}
+ */
+export function collectGlobalCategories(config) {
+  const assets = config?.assets ?? {};
+  const root = assets.root || "";
+
+  const globalCss = [
+    ...(assets.css || []),
+    ...(assets.shared?.css || []),
+  ]
+    .map((entry) => resolveAssetPath(entry, root))
+    .filter(Boolean);
+
+  const globalJs = [...(assets.js || []), ...(assets.shared?.js || [])]
+    .map((entry) => resolveAssetPath(entry, root))
+    .filter(Boolean);
+
+  const categories = [
+    { category: "global-css", label: "Global CSS", files: globalCss },
+    { category: "global-js", label: "Global JS", files: globalJs },
+  ];
+
+  for (const folder of assets.folder || []) {
+    const abs = path.resolve(root, folder);
+    categories.push({
+      category: `folder:${folder}`,
+      label: `Folder — ${folder}`,
+      files: walkFolder(abs),
+    });
+  }
+
+  return categories;
+}
+
+/**
+ * Build the list of categorised file sets for post-build HTML pages.
+ * @param {string} buildFolder
+ * @returns {{category: string, label: string, files: string[]}[]}
+ */
+export function collectHtmlCategory(buildFolder) {
+  const manifestPath = path.resolve(buildFolder, "output.json");
+
+  if (!fs.existsSync(manifestPath)) {
+    return [];
+  }
+
+  /** @type {Array<string|{path: string}>} */
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch {
+    return [];
+  }
+
+  const files = manifest
+    .map((entry) => (typeof entry === "string" ? entry : entry?.path))
+    .filter((rel) => typeof rel === "string" && rel.endsWith(".html"))
+    .map((rel) => path.resolve(buildFolder, rel));
+
+  return [{ category: "html", label: "Rendered HTML pages", files }];
+}
+
+/**
+ * @param {number|null} actual
+ * @param {number|null} budget
+ * @returns {{status: "ok"|"warn"|"exceed"|"unbudgeted", ratio: number|null}}
+ */
+function classify(actual, budget) {
+  if (budget == null) {
+    return { status: "unbudgeted", ratio: null };
+  }
+
+  if (budget <= 0) {
+    return { status: "unbudgeted", ratio: null };
+  }
+
+  const ratio = actual / budget;
+
+  if (actual > budget) {
+    return { status: "exceed", ratio };
+  }
+
+  if (ratio >= WARN_RATIO) {
+    return { status: "warn", ratio };
+  }
+
+  return { status: "ok", ratio };
+}
+
+/**
+ * Produce evaluation rows given a measurement and a budgets object.
+ * The shape of `budgets` is the `performance.budgets` config key; see
+ * lib/default-config.js for the canonical definition.
+ * @param {import("./measure.js").Measurement} measurement
+ * @param {object} budgets - performance.budgets config
+ * @param {"raw"|"gzip"|"brotli"} compression
+ * @param {{label: Record<string,string>}} meta - map category key -> human label
+ * @param {object} options
+ * @param {boolean} [options.listAllPages] - include every HTML page, not just those that exceed or warn
+ * @returns {EvaluationRow[]}
+ */
+export function evaluate(measurement, budgets = {}, compression = "gzip", meta = { label: {} }, options = {}) {
+  const rows = [];
+  const labelFor = (category) => meta.label[category] || category;
+
+  const globalBudgets = budgets.global || {};
+  const htmlBudgets = budgets.html || {};
+  const folderBudgets = budgets.folders || {};
+
+  // Global CSS / JS
+  for (const [category, budgetKey] of [
+    ["global-css", "css"],
+    ["global-js", "js"],
+  ]) {
+    const categoryMeasurement = measurement.categories[category];
+    if (!categoryMeasurement) {
+      continue;
+    }
+
+    const budget = parseSize(globalBudgets[budgetKey] ?? null);
+    const actual = categoryMeasurement.totals[compression];
+    const { status, ratio } = classify(actual, budget);
+
+    rows.push({
+      category,
+      key: "total",
+      label: labelFor(category),
+      actual,
+      budget,
+      status,
+      ratio,
+    });
+  }
+
+  // Global umbrella (CSS + JS) if set
+  if (globalBudgets.total != null) {
+    const cssTotal = measurement.categories["global-css"]?.totals[compression] ?? 0;
+    const jsTotal = measurement.categories["global-js"]?.totals[compression] ?? 0;
+    const actual = cssTotal + jsTotal;
+    const budget = parseSize(globalBudgets.total);
+    const { status, ratio } = classify(actual, budget);
+    rows.push({
+      category: "global",
+      key: "total",
+      label: "Global total (CSS + JS)",
+      actual,
+      budget,
+      status,
+      ratio,
+    });
+  }
+
+  // Folders
+  for (const [category, categoryMeasurement] of Object.entries(measurement.categories)) {
+    if (!category.startsWith("folder:")) {
+      continue;
+    }
+    const name = category.slice("folder:".length);
+    const folderBudget = folderBudgets[name];
+    const budget = parseSize(folderBudget?.total ?? null);
+    const actual = categoryMeasurement.totals[compression];
+    const { status, ratio } = classify(actual, budget);
+    rows.push({
+      category,
+      key: "total",
+      label: labelFor(category),
+      actual,
+      budget,
+      status,
+      ratio,
+    });
+  }
+
+  if (folderBudgets.total != null) {
+    let actual = 0;
+    for (const [category, categoryMeasurement] of Object.entries(measurement.categories)) {
+      if (category.startsWith("folder:")) {
+        actual += categoryMeasurement.totals[compression];
+      }
+    }
+    const budget = parseSize(folderBudgets.total);
+    const { status, ratio } = classify(actual, budget);
+    rows.push({
+      category: "folders",
+      key: "total",
+      label: "All folders total",
+      actual,
+      budget,
+      status,
+      ratio,
+    });
+  }
+
+  // HTML: one row per page for perPage, one row for the total.
+  // By default only pages that exceed or warn are listed — a project with many
+  // component variants can produce hundreds of pages and the table becomes noise.
+  // Pass options.listAllPages to include every page.
+  const htmlMeasurement = measurement.categories.html;
+  if (htmlMeasurement) {
+    const perPageBudget = parseSize(htmlBudgets.perPage ?? null);
+
+    if (perPageBudget != null) {
+      let pagesChecked = 0;
+      let pagesPassed = 0;
+
+      for (const file of htmlMeasurement.files) {
+        const actual = file[compression];
+        const { status, ratio } = classify(actual, perPageBudget);
+        pagesChecked++;
+
+        if (status === "ok") {
+          pagesPassed++;
+          if (!options.listAllPages) {
+            continue;
+          }
+        }
+
+        rows.push({
+          category: "html",
+          key: file.path,
+          label: path.basename(file.path),
+          actual,
+          budget: perPageBudget,
+          status,
+          ratio,
+        });
+      }
+
+      // When filtering, add a summary row so the reader knows pages were checked
+      if (!options.listAllPages && pagesPassed > 0) {
+        rows.push({
+          category: "html",
+          key: "pages-ok",
+          label: `${pagesPassed} of ${pagesChecked} pages within budget`,
+          actual: 0,
+          budget: null,
+          status: "ok",
+          ratio: null,
+        });
+      }
+    }
+
+    if (htmlBudgets.total != null) {
+      const actual = htmlMeasurement.totals[compression];
+      const budget = parseSize(htmlBudgets.total);
+      const { status, ratio } = classify(actual, budget);
+      rows.push({
+        category: "html",
+        key: "total",
+        label: "All pages total",
+        actual,
+        budget,
+        status,
+        ratio,
+      });
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Summarise evaluation rows into bucket counts.
+ * @param {EvaluationRow[]} rows
+ * @returns {{ok: number, warn: number, exceed: number, unbudgeted: number}}
+ */
+export function summarise(rows) {
+  const summary = { ok: 0, warn: 0, exceed: 0, unbudgeted: 0 };
+
+  for (const row of rows) {
+    summary[row.status] += 1;
+  }
+
+  return summary;
+}
+
+/**
+ * Run the full pipeline: collect → measure → evaluate → summarise.
+ * @param {object} [options]
+ * @param {object} [options.config] - override global.config, for tests
+ * @param {boolean} [options.html] - include post-build HTML measurement
+ * @param {string} [options.buildFolder] - required when html is true
+ * @param {boolean} [options.listAllPages] - list every HTML page, not just those that exceed or warn
+ * @returns {PerformanceResult}
+ */
+export function runPerformance(options = {}) {
+  const config = options.config ?? global.config;
+  const perfConfig = config?.performance ?? {};
+  const compression = perfConfig.compression || "gzip";
+  const budgets = perfConfig.budgets || {};
+
+  const categories = collectGlobalCategories(config);
+
+  if (options.html && options.buildFolder) {
+    categories.push(...collectHtmlCategory(options.buildFolder));
+  }
+
+  /** @type {Record<string, string>} */
+  const labelMap = {};
+  for (const category of categories) {
+    labelMap[category.category] = category.label;
+  }
+
+  const measurement = measure(
+    categories.map(({ category, files }) => ({ category, files })),
+  );
+
+  const evaluations = evaluate(measurement, budgets, compression, {
+    label: labelMap,
+  }, { listAllPages: options.listAllPages });
+  const summary = summarise(evaluations);
+
+  return { measurement, evaluations, compression, summary };
+}

--- a/lib/performance/measure.js
+++ b/lib/performance/measure.js
@@ -1,0 +1,124 @@
+/**
+ * Measure on-disk, gzip-compressed, and brotli-compressed sizes of files.
+ * Transfer size is what a user actually downloads, which is almost never the raw
+ * on-disk size — gzip and brotli are reported alongside raw so users can see all
+ * three and pick the metric their hosting actually serves.
+ * We measure whichever files the user has configured in their assets — source
+ * files, bundled output from esbuild/rollup/webpack, or anything else. Point
+ * `config.assets` at the files you actually ship and the budget reflects reality.
+ * Results are cached by absolute path + mtime. In dev the file watcher changes
+ * the mtime on every save, naturally invalidating the cache.
+ * @module performance/measure
+ */
+
+import fs from "node:fs";
+import zlib from "node:zlib";
+
+const cache = new Map();
+
+/**
+ * @typedef {object} FileMeasurement
+ * @property {string} path - absolute path
+ * @property {number} raw - on-disk byte length
+ * @property {number} gzip - gzip-compressed byte length
+ * @property {number} brotli - brotli-compressed byte length
+ * @property {boolean} [missing] - true when the file could not be read
+ */
+
+/**
+ * @typedef {object} CategoryMeasurement
+ * @property {FileMeasurement[]} files - per-file measurements in this category
+ * @property {{raw: number, gzip: number, brotli: number}} totals - sum across files
+ */
+
+/**
+ * @typedef {object} Measurement
+ * @property {Record<string, CategoryMeasurement>} categories - keyed by category name
+ * @property {{raw: number, gzip: number, brotli: number}} totals - sum across categories
+ */
+
+/**
+ * Clear the cached results. Intended for tests and for watcher-driven
+ * whole-state refreshes.
+ * @returns {void}
+ */
+export function clearMeasureCache() {
+  cache.clear();
+}
+
+/**
+ * @param {string} absPath
+ * @returns {FileMeasurement}
+ */
+function measureFile(absPath) {
+  // Open a file descriptor first, then stat and read through it. This avoids
+  // a race where the file is modified between stat and read — both operations
+  // now refer to the same version of the file.
+  let fd;
+  try {
+    fd = fs.openSync(absPath, "r");
+  } catch {
+    return { path: absPath, raw: 0, gzip: 0, brotli: 0, missing: true };
+  }
+
+  let stat;
+  let buffer;
+  try {
+    stat = fs.fstatSync(fd);
+    buffer = Buffer.alloc(stat.size);
+    fs.readSync(fd, buffer, 0, stat.size, 0);
+  } catch {
+    fs.closeSync(fd);
+    return { path: absPath, raw: 0, gzip: 0, brotli: 0, missing: true };
+  }
+  fs.closeSync(fd);
+
+  const cacheKey = `${absPath}:${stat.mtimeMs}:${stat.size}`;
+  const cached = cache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const measurement = {
+    path: absPath,
+    raw: buffer.byteLength,
+    gzip: zlib.gzipSync(buffer).byteLength,
+    // Brotli default is text mode with maximum quality which is _very_ slow on
+    // large files; use quality 6 to approximate what a CDN typically serves.
+    brotli: zlib.brotliCompressSync(buffer, {
+      params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 6 },
+    }).byteLength,
+  };
+
+  cache.set(cacheKey, measurement);
+  return measurement;
+}
+
+/**
+ * Measure a set of categorised file lists.
+ * @param {{category: string, files: string[]}[]} categorised
+ * @returns {Measurement}
+ */
+export function measure(categorised) {
+  /** @type {Record<string, CategoryMeasurement>} */
+  const categories = {};
+  const grand = { raw: 0, gzip: 0, brotli: 0 };
+
+  for (const { category, files } of categorised) {
+    const measured = files.map((absPath) => measureFile(absPath));
+    const totals = measured.reduce(
+      (acc, file) => ({
+        raw: acc.raw + file.raw,
+        gzip: acc.gzip + file.gzip,
+        brotli: acc.brotli + file.brotli,
+      }),
+      { raw: 0, gzip: 0, brotli: 0 },
+    );
+
+    categories[category] = { files: measured, totals };
+    grand.raw += totals.raw;
+    grand.gzip += totals.gzip;
+    grand.brotli += totals.brotli;
+  }
+
+  return { categories, totals: grand };
+}

--- a/lib/performance/parse-size.js
+++ b/lib/performance/parse-size.js
@@ -1,0 +1,86 @@
+/**
+ * Human-friendly size parser for performance budgets.
+ * Accepts either a bare number (bytes) or a string with a SI-ish unit suffix.
+ * Recognised units (case-insensitive): B, kB, KB, MB, GB. The number may be
+ * a decimal (e.g. "1.5 MB") and whitespace between number and unit is optional.
+ * Uses the decimal convention (1 kB = 1000 B) because that is what web performance
+ * budgets are traditionally expressed in — it matches the web.dev budget guidance
+ * and the way transfer sizes are reported in browser devtools.
+ * @module performance/parse-size
+ */
+
+const ONE_KILOBYTE = 1000;
+const ONE_MEGABYTE = 1000 * 1000;
+const ONE_GIGABYTE = 1000 * 1000 * 1000;
+
+const UNIT_MULTIPLIERS = {
+  b: 1,
+  kb: ONE_KILOBYTE,
+  mb: ONE_MEGABYTE,
+  gb: ONE_GIGABYTE,
+};
+
+/**
+ * Parse a size value into bytes.
+ * @param {string|number|null|undefined} value
+ * @returns {number|null} bytes, or null when value is null/undefined
+ * @throws {TypeError} if value cannot be parsed
+ */
+export default function parseSize(value) {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value < 0) {
+      throw new TypeError(`Invalid size value: ${value}`);
+    }
+
+    return Math.round(value);
+  }
+
+  if (typeof value !== "string") {
+    throw new TypeError(`Invalid size value: ${value}`);
+  }
+
+  const trimmed = value.trim();
+  // Match a number (integer or decimal) optionally followed by a unit suffix.
+  // Examples: "50", "1.5 kB", "200MB", "2048 B"
+  //   Group 1: the numeric part (e.g. "1.5")
+  //   Group 2: the unit part, may be empty (e.g. "kB", "MB", or "")
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([a-zA-Z]*)$/);
+
+  if (!match) {
+    throw new TypeError(`Invalid size value: ${value}`);
+  }
+
+  const amount = Number.parseFloat(match[1]);
+  const unit = (match[2] || "b").toLowerCase();
+
+  if (!(unit in UNIT_MULTIPLIERS)) {
+    throw new TypeError(`Unknown size unit "${match[2]}" in "${value}"`);
+  }
+
+  return Math.round(amount * UNIT_MULTIPLIERS[unit]);
+}
+
+/**
+ * Format a number of bytes as a human-friendly string (for display / reports).
+ * @param {number|null} bytes
+ * @returns {string}
+ */
+export function formatSize(bytes) {
+  if (bytes == null) {
+    return "—";
+  }
+
+  if (bytes < ONE_KILOBYTE) {
+    return `${bytes} B`;
+  }
+
+  if (bytes < ONE_MEGABYTE) {
+    return `${(bytes / ONE_KILOBYTE).toFixed(2)} kB`;
+  }
+
+  return `${(bytes / ONE_MEGABYTE).toFixed(2)} MB`;
+}

--- a/lib/performance/report.js
+++ b/lib/performance/report.js
@@ -1,0 +1,102 @@
+/**
+ * Generate a Markdown performance-budget report.
+ * Mirrors the shape of lib/validator/html-report.js so the two read the same at
+ * a glance: one summary table, then per-category detail tables. The report is
+ * a stable artefact that can be committed by CI or linked from PRs.
+ * @module performance/report
+ */
+
+import path from "node:path";
+import { formatSize } from "./parse-size.js";
+
+const STATUS_LABEL = {
+  ok: "OK",
+  warn: "WARN",
+  exceed: "EXCEED",
+  unbudgeted: "—",
+};
+
+/**
+ * @param {"raw"|"gzip"|"brotli"} compression
+ * @returns {string}
+ */
+function compressionLabel(compression) {
+  return compression.charAt(0).toUpperCase() + compression.slice(1);
+}
+
+/**
+ * @param {import("./index.js").PerformanceResult} result
+ * @param {object} [options]
+ * @param {string} [options.cwd] - used to relativize reported file paths
+ * @returns {string} Markdown
+ */
+export function generatePerformanceReport(result, options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const { measurement, evaluations, compression, summary } = result;
+  const lines = [];
+
+  lines.push("# Performance Budget Report");
+  lines.push("");
+  lines.push(`**Date:** ${new Date().toISOString().split("T")[0]}`);
+  lines.push(`**Compression:** ${compressionLabel(compression)}`);
+  lines.push(
+    `**OK:** ${summary.ok} | **Warn:** ${summary.warn} | **Exceed:** ${summary.exceed} | **Unbudgeted:** ${summary.unbudgeted}`,
+  );
+  lines.push("");
+
+  // Evaluation summary
+  lines.push("## Evaluations");
+  lines.push("");
+  lines.push("| Category | Item | Actual | Budget | Status |");
+  lines.push("|----------|------|--------|--------|--------|");
+
+  for (const row of evaluations) {
+    let itemLabel;
+    if (row.key === "total") {
+      itemLabel = "Total";
+    } else if (row.key === "perPage") {
+      itemLabel = "Per page";
+    } else {
+      itemLabel = escapePipe(row.label);
+    }
+
+    lines.push(
+      `| ${escapePipe(row.category)} | ${itemLabel} | ${formatSize(row.actual)} | ${formatSize(row.budget)} | ${STATUS_LABEL[row.status]} |`,
+    );
+  }
+  lines.push("");
+
+  // Per-category file breakdown
+  for (const [category, data] of Object.entries(measurement.categories)) {
+    if (data.files.length === 0) {
+      continue;
+    }
+
+    lines.push(`## ${escapePipe(category)}`);
+    lines.push("");
+    lines.push("| File | Raw | Gzip | Brotli |");
+    lines.push("|------|-----|------|--------|");
+
+    for (const file of data.files) {
+      const rel = path.relative(cwd, file.path);
+      const label = file.missing ? `${rel} (missing)` : rel;
+      lines.push(
+        `| ${escapePipe(label)} | ${formatSize(file.raw)} | ${formatSize(file.gzip)} | ${formatSize(file.brotli)} |`,
+      );
+    }
+    lines.push(
+      `| **Total** | ${formatSize(data.totals.raw)} | ${formatSize(data.totals.gzip)} | ${formatSize(data.totals.brotli)} |`,
+    );
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function escapePipe(text) {
+  return String(text).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}

--- a/lib/render/index.js
+++ b/lib/render/index.js
@@ -15,6 +15,8 @@ import renderMainDocs from "./views/main/docs.js";
 import renderMainIndex from "./views/main/index.js";
 import iframeDesignTokens from "./views/iframe/design-tokens/index.js";
 import renderMainDesignTokens from "./views/main/design-tokens.js";
+import renderMainPerformance from "./views/main/performance.js";
+import renderIframePerformance from "./views/iframe/performance.js";
 
 export default {
   renderMainIndex,
@@ -28,11 +30,13 @@ export default {
   renderIframeDocs,
   renderIframeIndex,
   renderMainDesignTokens,
+  renderMainPerformance,
   iframe: {
     designTokens: {
       colors: iframeDesignTokens.colors,
       sizes: iframeDesignTokens.sizes,
       typography: iframeDesignTokens.typography,
     },
+    performance: renderIframePerformance,
   },
 };

--- a/lib/render/views/iframe/performance.js
+++ b/lib/render/views/iframe/performance.js
@@ -1,0 +1,74 @@
+import config from "../../../default-config.js";
+import { getUserUiConfig, getThemeMode } from "../../helpers.js";
+import { runPerformance } from "../../../performance/index.js";
+import { formatSize } from "../../../performance/parse-size.js";
+
+/**
+ * Renders the iframe-side Performance panel. Computed on-request so the
+ * numbers reflect the current on-disk state without any extra cache plumbing;
+ * `measure.js` has an mtime cache so repeat renders are cheap.
+ * @param {object} o
+ * @param {object} o.res
+ * @param {Function} [o.cb]
+ * @param {object} o.cookies
+ * @returns {Promise<void>}
+ */
+export default async function renderIframePerformance({ res, cb, cookies }) {
+  const themeMode = getThemeMode(cookies);
+
+  const result = runPerformance({ config: global.config });
+
+  const viewData = {
+    compression: result.compression,
+    evaluations: result.evaluations.map((row) => ({
+      ...row,
+      actualFormatted: formatSize(row.actual),
+      budgetFormatted: formatSize(row.budget),
+      ratioPercent:
+        row.ratio == null ? null : Math.round(row.ratio * 100),
+    })),
+    categories: Object.entries(result.measurement.categories).map(
+      ([category, data]) => ({
+        category,
+        files: data.files.map((file) => ({
+          path: file.path,
+          raw: formatSize(file.raw),
+          gzip: formatSize(file.gzip),
+          brotli: formatSize(file.brotli),
+          missing: !!file.missing,
+        })),
+        totals: {
+          raw: formatSize(data.totals.raw),
+          gzip: formatSize(data.totals.gzip),
+          brotli: formatSize(data.totals.brotli),
+        },
+      }),
+    ),
+    summary: result.summary,
+  };
+
+  await res.render(
+    "performance.twig.miyagi",
+    {
+      ...viewData,
+      isBuild: global.config.isBuild,
+      lang: global.config.ui.lang,
+      miyagiDev: !!process.env.MIYAGI_DEVELOPMENT,
+      projectName: config.projectName,
+      userUiConfig: getUserUiConfig(cookies),
+      theme: themeMode
+        ? Object.assign(global.config.ui.theme, { mode: themeMode })
+        : global.config.ui.theme,
+      uiTextDirection: global.config.ui.textDirection,
+    },
+    (html) => {
+      if (res.send) {
+        res.send(html);
+      }
+
+      if (cb) {
+        cb(null, html);
+      }
+    },
+  );
+}

--- a/lib/render/views/main/performance.js
+++ b/lib/render/views/main/performance.js
@@ -1,0 +1,51 @@
+import config from "../../../default-config.js";
+import { getUserUiConfig, getThemeMode } from "../../helpers.js";
+
+/**
+ * Renders the main Performance page — the standard chrome (menu etc.) with
+ * the iframe pointed at the Performance panel view.
+ * @param {object} object
+ * @param {object} object.res
+ * @param {Function} [object.cb]
+ * @param {object} [object.cookies]
+ * @returns {void}
+ */
+export default function renderMainPerformance({ res, cb, cookies }) {
+  const themeMode = getThemeMode(cookies);
+
+  res.render(
+    "main.twig.miyagi",
+    {
+      lang: global.config.ui.lang,
+      folders: global.state.menu,
+      components: global.state.components,
+      flatUrlPattern: global.config.isBuild
+        ? "/show-{{component}}.html"
+        : "/show?file={{component}}",
+      iframeSrc: "/iframe/performance",
+      showAll: true,
+      projectName: config.projectName,
+      userProjectName: global.config.projectName,
+      indexPath: global.config.indexPath.embedded,
+      miyagiDev: !!process.env.MIYAGI_DEVELOPMENT,
+      isBuild: global.config.isBuild,
+      userUiConfig: getUserUiConfig(cookies),
+      theme: themeMode
+        ? Object.assign(global.config.ui.theme, { mode: themeMode })
+        : global.config.ui.theme,
+      basePath: global.config.isBuild ? global.config.build.basePath : "/",
+      uiTextDirection: global.config.ui.textDirection,
+      requestedComponent: "performance",
+      requestedVariation: null,
+    },
+    (html) => {
+      if (res.send) {
+        res.send(html);
+      }
+
+      if (cb) {
+        cb(null, html);
+      }
+    },
+  );
+}

--- a/lib/state/menu/index.js
+++ b/lib/state/menu/index.js
@@ -221,17 +221,58 @@ export const getMenu = function (sourceTree) {
 
   const docsMenu = getDocsMenu(sourceTree.docs);
   const designTokensMenu = getDesignTokensMenu();
+  const performanceMenu = getPerformanceMenu();
 
-  if (!docsMenu && !designTokensMenu && componentsMenu)
+  if (!docsMenu && !designTokensMenu && !performanceMenu && componentsMenu) {
     return componentsMenu.children;
+  }
 
   const menus = [];
-  if (designTokensMenu) menus.push(designTokensMenu);
-  if (componentsMenu) menus.push(componentsMenu);
-  if (docsMenu) menus.push(docsMenu);
+  if (designTokensMenu) {
+    menus.push(designTokensMenu);
+  }
+  if (componentsMenu) {
+    menus.push(componentsMenu);
+  }
+  if (docsMenu) {
+    menus.push(docsMenu);
+  }
+  if (performanceMenu) {
+    menus.push(performanceMenu);
+  }
 
   return menus;
 };
+
+/**
+ * @returns {object|null}
+ */
+function getPerformanceMenu() {
+  // Dev-mode only. In build output there is no live dev-server to compute
+  // perf against, so the entry would dead-link.
+  if (global.config.isBuild) {
+    return null;
+  }
+  if (!global.config.performance?.enabled) {
+    return null;
+  }
+
+  return {
+    topLevel: true,
+    name: "Performance",
+    id: "performance",
+    type: "directory",
+    shortPath: "performance",
+    children: [
+      {
+        section: "performance",
+        type: "file",
+        name: "budget",
+        url: "/iframe/performance",
+      },
+    ],
+  };
+}
 
 /**
  * @returns {object}

--- a/starlight/astro.config.mjs
+++ b/starlight/astro.config.mjs
@@ -90,6 +90,10 @@ export default defineConfig({
               label: "Validating HTML",
               slug: "cli-commands/validating-html",
             },
+            {
+              label: "Performance budget",
+              slug: "cli-commands/performance-budget",
+            },
           ],
         },
         {

--- a/starlight/src/content/docs/cli-commands/index.md
+++ b/starlight/src/content/docs/cli-commands/index.md
@@ -23,6 +23,7 @@ npx miyagi <command>
 | `miyagi lint`          | Validate schema files and mock data                  | [Linting mock data](/cli-commands/linting-mock-data/)             |
 | `miyagi drupal-assets` | Resolve Drupal component assets into `$assets`       | [Resolving Drupal assets](/cli-commands/resolving-drupal-assets/) |
 | `miyagi doctor`        | Check config and environment for common setup issues | [Running doctor](/cli-commands/running-doctor/)                   |
+| `miyagi budget`        | Check asset sizes against a performance budget       | [Performance budget](/cli-commands/performance-budget/)           |
 
 ## Global options
 

--- a/starlight/src/content/docs/cli-commands/performance-budget.md
+++ b/starlight/src/content/docs/cli-commands/performance-budget.md
@@ -1,0 +1,124 @@
+---
+title: "Performance budget"
+---
+
+_miyagi_ can track the byte size of the assets it ships — global CSS, global JS, static asset folders, and (post-build) rendered HTML pages — against a configured performance budget. Because _miyagi_ already owns the authoritative list of assets for your component library, it's a natural place to run this check.
+
+Budgets are enforced in three places:
+
+1. **On-demand**: `miyagi budget` prints a table of current vs. budgeted sizes.
+2. **Build-time**: `miyagi build` writes a `performance-report.md` alongside `output.json` and logs a one-line summary. Non-failing by default.
+3. **Dev server**: a **Performance** entry in the menu (dev-mode only) shows the live table, updated on each render.
+
+## On-demand check
+
+```bash
+miyagi budget
+```
+
+Prints an evaluation table to stdout with columns `Category | Item | Actual | Budget | Status`. Exits `0` unless `--fail` is set.
+
+### Options
+
+| Option            | Purpose                                                                     |
+| ----------------- | --------------------------------------------------------------------------- |
+| `--compression`   | `raw`, `gzip`, or `brotli` — overrides the configured compression metric    |
+| `--fail`          | Exit non-zero (`4`) if any budget is exceeded                               |
+| `--json`          | Emit the raw evaluation as JSON on stdout (for CI / automation)             |
+| `--output`, `-o`  | Also write a markdown report to this path                                   |
+| `--build-folder`  | Include post-build HTML pages from this folder (reads `output.json`)        |
+| `--list-all-pages` | List every HTML page, not just those that exceed or warn                   |
+
+## Configuration
+
+Configure in `.miyagi.js` / `.miyagi.mjs`:
+
+```js
+export default {
+  performance: {
+    enabled: true,
+    compression: "gzip", // "raw" | "gzip" | "brotli"
+    report: {
+      failOnExceed: false,
+      output: "performance-report.md", // bare filename lands inside build/
+    },
+    budgets: {
+      global: {
+        css: "35 kB",
+        js: "200 kB",
+        total: null, // optional umbrella across CSS + JS
+      },
+      html: {
+        perPage: "30 kB",
+        total: null,
+      },
+      folders: {
+        fonts: { total: "30 kB" },
+        images: { total: "50 kB" },
+        total: null,
+      },
+    },
+  },
+};
+```
+
+Sizes accept human strings (`"50 kB"`, `"1.5 MB"`) or plain numbers (bytes). `null` disables budgeting for that slot — the file is still measured and shown, just not evaluated.
+
+### Status semantics
+
+- **OK** — under 80% of budget
+- **WARN** — at or above 80% of budget
+- **EXCEED** — over budget
+- **—** (unbudgeted) — no budget set for this category
+
+## Default budgets & sources
+
+The defaults (Global CSS: 35 kB, Global JS: 200 kB, HTML per page: 30 kB, Fonts folder: 30 kB, Images folder: 50 kB) track the **Slow 4G / Moto G4** tier from web.dev's "Your First Performance Budget" guide. All values are gzip-compressed transfer bytes — matches the `compression: "gzip"` default, which is in turn the convention established by ["Performance Budgets 101"](https://web.dev/articles/performance-budgets-101).
+
+These are a **starting point**, not a verdict. Real budgets should be derived from your own performance goals and real-user data.
+
+Sources:
+
+- **[Your First Performance Budget](https://web.dev/articles/your-first-performance-budget)** (Addy Osmani & Kayce Basques, web.dev) — the tiered per-category kB table our defaults track. Projects targeting emerging markets may prefer the Slow 3G tier (100 kB JS, 10 kB CSS, 30 kB HTML). Projects targeting desktop-primarily may lift to the WiFi tier (300 kB JS, 50 kB CSS, 100 kB fonts).
+- **[Performance Budgets 101](https://web.dev/articles/performance-budgets-101)** (web.dev) — establishes the ~170 kB critical-path budget for mobile 3G and the framing that budgets should be expressed in gzipped/minified transfer size.
+- **[SpeedCurve — Web Performance Budgets](https://www.speedcurve.com/web-performance-guide/performance-budgets/)** — framing and terminology. Numerical baselines live in the SpeedCurve product rather than the public guide.
+- **[HTTP Archive — Page Weight report](https://httparchive.org/reports/page-weight)** — useful as a "current reality" baseline (what median sites actually ship), not as a prescriptive target.
+
+## Build-time reporting
+
+`miyagi build` runs the budget check automatically after writing `output.json`:
+
+```bash
+miyagi build
+# → Performance budget (gzip): 3 ok, 1 warn, 0 exceed, 2 unbudgeted.
+# → Wrote build/performance-report.md.
+```
+
+The report is always written; the build only fails when `performance.report.failOnExceed: true` and something is over budget.
+
+## Dev server
+
+With `miyagi start`, a **Performance** entry appears in the sidebar (dev-mode only — it is never generated into a static build). The panel renders the same table as the CLI, refreshed on each request. A JSON endpoint is also available at `/api/performance` for tooling integrations.
+
+## CI usage
+
+```bash
+miyagi budget --fail --json > budget.json
+```
+
+Combined with `--output` you can commit / post the markdown report as a PR artefact.
+
+## Exit codes
+
+- `0` — within budget (or exceed observed but `--fail` not set)
+- `2` — CLI usage error
+- `4` — budget exceeded with `--fail` or `performance.report.failOnExceed: true`
+
+## What's measured today
+
+- Global CSS (`config.assets.css` + `config.assets.shared.css`)
+- Global JS (`config.assets.js` + `config.assets.shared.js`)
+- Each configured asset folder (`config.assets.folder[]`), aggregated
+- Each rendered HTML page (build-time only, iterated from `output.json`)
+
+Per-component budgets are reserved in the config shape (`budgets.perComponent`) but not yet evaluated — that is planned for a follow-up.

--- a/starlight/src/content/docs/configuration/default-configuration.md
+++ b/starlight/src/content/docs/configuration/default-configuration.md
@@ -100,6 +100,39 @@ export default {
       }
     },
   namespaces: {},
+  performance: {
+      enabled: true,
+      compression: "gzip",
+      report: {
+        failOnExceed: false,
+        output: "performance-report.md"
+      },
+      budgets: {
+        global: {
+          css: "35 kB",
+          js: "200 kB",
+          total: null
+        },
+        html: {
+          perPage: "30 kB",
+          total: null
+        },
+        folders: {
+          fonts: {
+            total: "30 kB"
+          },
+          images: {
+            total: "50 kB"
+          },
+          total: null
+        },
+        perComponent: {
+          css: null,
+          js: null,
+          total: null
+        }
+      }
+    },
   projectName: "miyagi",
   ui: {
       mode: "light",

--- a/starlight/src/content/docs/configuration/options.md
+++ b/starlight/src/content/docs/configuration/options.md
@@ -333,6 +333,64 @@ Example:
 }
 ```
 
+## `performance`
+
+_Performance-budget settings. See [Performance budget](/cli-commands/performance-budget/) for full context, including the web.dev sources behind the default numbers._
+
+### `enabled`
+
+default: `true`<br>
+type: `boolean`
+
+Turn the feature on or off. When `false`, the `miyagi budget` command still works but build-time reporting and the dev-UI Performance panel are suppressed.
+
+### `compression`
+
+default: `"gzip"`<br>
+type: `string`<br>
+values: `raw|gzip|brotli`
+
+Which compression to compare against the configured budgets. `raw` and `brotli` are always measured alongside — changing this only changes which number is evaluated.
+
+### `report.failOnExceed`
+
+default: `false`<br>
+type: `boolean`
+
+When `true`, `miyagi build` exits non-zero if any budget is exceeded.
+
+### `report.output`
+
+default: `"performance-report.md"`<br>
+type: `string`
+
+Where the markdown report is written during `miyagi build`. A bare filename lands inside the build folder; a path with a directory component is honoured as-is.
+
+### `budgets.global.{css,js,total}`
+
+default: `"35 kB"` (css), `"200 kB"` (js), `null` (total)<br>
+type: `string|number|null`
+
+Budgets for global CSS (`assets.css` + `assets.shared.css`), global JS, and an optional umbrella total across both. Accepts human strings (`"50 kB"`) or bytes. `null` disables.
+
+### `budgets.html.{perPage,total}`
+
+default: `"30 kB"` (perPage), `null` (total)<br>
+type: `string|number|null`
+
+Applied to rendered HTML pages in `miyagi build` output. `perPage` is checked against every page individually; `total` sums them all.
+
+### `budgets.folders.<name>.total`, `budgets.folders.total`
+
+default: `"30 kB"` (fonts), `"50 kB"` (images), `null` (umbrella)<br>
+type: `string|number|null`
+
+Per-folder budgets, keyed by the folder name configured in `assets.folder[]`. Add/rename freely — the defaults are illustrative.
+
+### `budgets.perComponent.*`
+
+Reserved for a future per-component evaluation pass. No effect yet.
+
 ## `ui`
 
 _Settings for the [web UI](/the-ui)._

--- a/starlight/src/content/docs/javascript-api.md
+++ b/starlight/src/content/docs/javascript-api.md
@@ -260,6 +260,37 @@ Promise<{
 }>
 ```
 
+### `getPerformance`
+
+Run the performance-budget check programmatically. See [Performance budget](/cli-commands/performance-budget/) for configuration details.
+
+#### Options
+
+```js
+{
+ html: Boolean, // Optional — include post-build HTML pages
+ buildFolder: String, // Required when `html` is true — reads output.json from this folder
+ compression: "raw"|"gzip"|"brotli" // Optional — override the configured compression
+}
+```
+
+#### Response
+
+```js
+Promise<{
+ success: Boolean, // true when no budget has been exceeded
+ data: {
+  result: {
+   measurement: Object, // raw byte sizes per category
+   evaluations: Array,  // per-row budget status
+   compression: String,
+   summary: { ok: Number, warn: Number, exceed: Number, unbudgeted: Number }
+  },
+  report: String // Markdown-formatted report
+ }
+}>
+```
+
 ## Usage
 
 ```js

--- a/tests/api/index.test.js
+++ b/tests/api/index.test.js
@@ -209,7 +209,7 @@ describe("createBuild", () => {
 
     expect(await createBuild()).toStrictEqual({
       success: true,
-      message: "Build done! Wrote 118 directories and files.",
+      message: "Build done! Wrote 119 directories and files.",
     });
 
     [

--- a/tests/lib/performance/evaluate.test.js
+++ b/tests/lib/performance/evaluate.test.js
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "vitest";
+import { evaluate, summarise } from "../../../lib/performance/index.js";
+
+/**
+ * @param {Record<string, {raw: number, gzip: number, brotli: number}>} byCat
+ * @returns {import("../../../lib/performance/measure.js").Measurement}
+ */
+function fakeMeasurement(byCat) {
+  const categories = {};
+  const totals = { raw: 0, gzip: 0, brotli: 0 };
+  for (const [cat, t] of Object.entries(byCat)) {
+    categories[cat] = { files: [], totals: t };
+    totals.raw += t.raw;
+    totals.gzip += t.gzip;
+    totals.brotli += t.brotli;
+  }
+  return { categories, totals };
+}
+
+describe("evaluate", () => {
+  test("classifies ok / warn / exceed correctly at boundaries", () => {
+    const measurement = fakeMeasurement({
+      "global-css": { raw: 0, gzip: 34999, brotli: 0 },
+      "global-js": { raw: 0, gzip: 160001, brotli: 0 },
+    });
+
+    const rows = evaluate(
+      measurement,
+      {
+        global: { css: "35 kB", js: "200 kB" },
+      },
+      "gzip",
+    );
+
+    const cssRow = rows.find((r) => r.category === "global-css");
+    const jsRow = rows.find((r) => r.category === "global-js");
+
+    // 34999 / 35000 = 0.99+ → warn (>= 80%)
+    expect(cssRow.status).toBe("warn");
+    // 160001 / 200000 = 0.80+ → warn
+    expect(jsRow.status).toBe("warn");
+  });
+
+  test("flags exceed when over budget", () => {
+    const measurement = fakeMeasurement({
+      "global-css": { raw: 0, gzip: 50000, brotli: 0 },
+      "global-js": { raw: 0, gzip: 10, brotli: 0 },
+    });
+
+    const rows = evaluate(
+      measurement,
+      { global: { css: "35 kB", js: "200 kB" } },
+      "gzip",
+    );
+
+    expect(rows.find((r) => r.category === "global-css").status).toBe("exceed");
+    expect(rows.find((r) => r.category === "global-js").status).toBe("ok");
+  });
+
+  test("marks categories without a budget as unbudgeted", () => {
+    const measurement = fakeMeasurement({
+      "global-css": { raw: 0, gzip: 1, brotli: 0 },
+      "global-js": { raw: 0, gzip: 1, brotli: 0 },
+    });
+
+    const rows = evaluate(measurement, {}, "gzip");
+    for (const row of rows) {
+      expect(row.status).toBe("unbudgeted");
+      expect(row.budget).toBe(null);
+    }
+  });
+
+  test("respects selected compression metric", () => {
+    const measurement = fakeMeasurement({
+      "global-css": { raw: 100000, gzip: 30000, brotli: 25000 },
+      "global-js": { raw: 0, gzip: 0, brotli: 0 },
+    });
+
+    const gzipRows = evaluate(measurement, { global: { css: "35 kB" } }, "gzip");
+    const rawRows = evaluate(measurement, { global: { css: "35 kB" } }, "raw");
+
+    expect(gzipRows.find((r) => r.category === "global-css").status).toBe(
+      "warn",
+    );
+    expect(rawRows.find((r) => r.category === "global-css").status).toBe(
+      "exceed",
+    );
+  });
+
+  test("evaluates folder budgets and per-page HTML, filtering passing pages by default", () => {
+    const measurement = {
+      categories: {
+        "global-css": { files: [], totals: { raw: 0, gzip: 0, brotli: 0 } },
+        "global-js": { files: [], totals: { raw: 0, gzip: 0, brotli: 0 } },
+        "folder:fonts": {
+          files: [],
+          totals: { raw: 0, gzip: 40000, brotli: 0 },
+        },
+        html: {
+          files: [
+            { path: "/b/a.html", raw: 0, gzip: 35000, brotli: 0 },
+            { path: "/b/b.html", raw: 0, gzip: 10000, brotli: 0 },
+          ],
+          totals: { raw: 0, gzip: 45000, brotli: 0 },
+        },
+      },
+      totals: { raw: 0, gzip: 85000, brotli: 0 },
+    };
+
+    const budgets = {
+      folders: { fonts: { total: "30 kB" } },
+      html: { perPage: "30 kB", total: "100 kB" },
+    };
+
+    const rows = evaluate(measurement, budgets, "gzip");
+
+    expect(rows.find((r) => r.category === "folder:fonts").status).toBe(
+      "exceed",
+    );
+
+    // a.html exceeds the 30 kB per-page budget — should be listed
+    const aPage = rows.find((r) => r.key === "/b/a.html");
+    expect(aPage.status).toBe("exceed");
+
+    // b.html is within budget — should NOT appear by default
+    const bPage = rows.find((r) => r.key === "/b/b.html");
+    expect(bPage).toBeUndefined();
+
+    // A summary row should note the passing page
+    const pagesOk = rows.find((r) => r.key === "pages-ok");
+    expect(pagesOk).toBeDefined();
+    expect(pagesOk.label).toContain("1 of 2");
+
+    const htmlTotal = rows.find(
+      (r) => r.category === "html" && r.key === "total",
+    );
+    expect(htmlTotal.status).toBe("ok");
+  });
+
+  test("lists all HTML pages when listAllPages option is set", () => {
+    const measurement = {
+      categories: {
+        "global-css": { files: [], totals: { raw: 0, gzip: 0, brotli: 0 } },
+        "global-js": { files: [], totals: { raw: 0, gzip: 0, brotli: 0 } },
+        html: {
+          files: [
+            { path: "/b/a.html", raw: 0, gzip: 35000, brotli: 0 },
+            { path: "/b/b.html", raw: 0, gzip: 10000, brotli: 0 },
+          ],
+          totals: { raw: 0, gzip: 45000, brotli: 0 },
+        },
+      },
+      totals: { raw: 0, gzip: 45000, brotli: 0 },
+    };
+
+    const rows = evaluate(
+      measurement,
+      { html: { perPage: "30 kB" } },
+      "gzip",
+      { label: {} },
+      { listAllPages: true },
+    );
+
+    const aPage = rows.find((r) => r.key === "/b/a.html");
+    const bPage = rows.find((r) => r.key === "/b/b.html");
+    expect(aPage.status).toBe("exceed");
+    expect(bPage.status).toBe("ok");
+
+    // No summary row when all pages are shown
+    expect(rows.find((r) => r.key === "pages-ok")).toBeUndefined();
+  });
+});
+
+describe("summarise", () => {
+  test("buckets statuses", () => {
+    const summary = summarise([
+      { status: "ok" },
+      { status: "warn" },
+      { status: "warn" },
+      { status: "exceed" },
+      { status: "unbudgeted" },
+    ]);
+    expect(summary).toEqual({ ok: 1, warn: 2, exceed: 1, unbudgeted: 1 });
+  });
+});

--- a/tests/lib/performance/measure.test.js
+++ b/tests/lib/performance/measure.test.js
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import zlib from "node:zlib";
+import {
+  clearMeasureCache,
+  measure,
+} from "../../../lib/performance/measure.js";
+
+let tmp;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "miyagi-measure-"));
+  clearMeasureCache();
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/**
+ * @param {string} name
+ * @param {string} contents
+ * @returns {string}
+ */
+function write(name, contents) {
+  const filePath = path.join(tmp, name);
+  fs.writeFileSync(filePath, contents);
+  return filePath;
+}
+
+describe("measure", () => {
+  test("returns raw/gzip/brotli byte lengths matching zlib", () => {
+    const contents = "body { color: red; }".repeat(50);
+    const file = write("a.css", contents);
+
+    const result = measure([{ category: "global-css", files: [file] }]);
+
+    const raw = Buffer.byteLength(contents);
+    const gzip = zlib.gzipSync(Buffer.from(contents)).byteLength;
+    const brotli = zlib.brotliCompressSync(Buffer.from(contents), {
+      params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 6 },
+    }).byteLength;
+
+    const [measured] = result.categories["global-css"].files;
+    expect(measured.raw).toBe(raw);
+    expect(measured.gzip).toBe(gzip);
+    expect(measured.brotli).toBe(brotli);
+  });
+
+  test("sums totals per category and overall", () => {
+    const a = write("a.js", "a".repeat(1000));
+    const b = write("b.js", "b".repeat(2000));
+    const c = write("c.css", "c".repeat(500));
+
+    const result = measure([
+      { category: "global-js", files: [a, b] },
+      { category: "global-css", files: [c] },
+    ]);
+
+    expect(result.categories["global-js"].totals.raw).toBe(3000);
+    expect(result.categories["global-css"].totals.raw).toBe(500);
+    expect(result.totals.raw).toBe(3500);
+  });
+
+  test("marks missing files but does not throw", () => {
+    const ghost = path.join(tmp, "does-not-exist.js");
+    const result = measure([{ category: "global-js", files: [ghost] }]);
+
+    const [measured] = result.categories["global-js"].files;
+    expect(measured.missing).toBe(true);
+    expect(measured.raw).toBe(0);
+    expect(result.totals.raw).toBe(0);
+  });
+
+  test("caches by mtime — unchanged file is not re-read into different numbers", () => {
+    const file = write("a.txt", "hello");
+    const first = measure([{ category: "a", files: [file] }]);
+    const second = measure([{ category: "a", files: [file] }]);
+
+    expect(first.categories.a.files[0]).toEqual(second.categories.a.files[0]);
+  });
+});

--- a/tests/lib/performance/parse-size.test.js
+++ b/tests/lib/performance/parse-size.test.js
@@ -1,0 +1,64 @@
+import { describe, test, expect } from "vitest";
+import parseSize, {
+  formatSize,
+} from "../../../lib/performance/parse-size.js";
+
+describe("parseSize", () => {
+  test("returns null for null / undefined", () => {
+    expect(parseSize(null)).toBe(null);
+    expect(parseSize(undefined)).toBe(null);
+  });
+
+  test("treats bare numbers as bytes", () => {
+    expect(parseSize(0)).toBe(0);
+    expect(parseSize(1024)).toBe(1024);
+    expect(parseSize(1.9)).toBe(2);
+  });
+
+  test("parses decimal kB / KB / MB / GB units", () => {
+    expect(parseSize("50 kB")).toBe(50000);
+    expect(parseSize("50KB")).toBe(50000);
+    expect(parseSize("1.5 MB")).toBe(1500000);
+    expect(parseSize("2 GB")).toBe(2000000000);
+  });
+
+  test("is case-insensitive and tolerates missing whitespace", () => {
+    expect(parseSize("35kb")).toBe(35000);
+    expect(parseSize("35 KB")).toBe(35000);
+    expect(parseSize("35 Kb")).toBe(35000);
+  });
+
+  test("treats plain digit strings as bytes (implicit B)", () => {
+    expect(parseSize("1024")).toBe(1024);
+    expect(parseSize("2048 B")).toBe(2048);
+  });
+
+  test("throws for garbage strings", () => {
+    expect(() => parseSize("not a size")).toThrow(TypeError);
+    expect(() => parseSize("50 tb")).toThrow(TypeError);
+    expect(() => parseSize("")).toThrow(TypeError);
+  });
+
+  test("throws for negative or non-finite numbers", () => {
+    expect(() => parseSize(-10)).toThrow(TypeError);
+    expect(() => parseSize(Number.POSITIVE_INFINITY)).toThrow(TypeError);
+    expect(() => parseSize(Number.NaN)).toThrow(TypeError);
+  });
+});
+
+describe("formatSize", () => {
+  test("formats null / undefined as em-dash", () => {
+    expect(formatSize(null)).toBe("—");
+    expect(formatSize(undefined)).toBe("—");
+  });
+
+  test("formats bytes under 1 kB as plain bytes", () => {
+    expect(formatSize(0)).toBe("0 B");
+    expect(formatSize(512)).toBe("512 B");
+  });
+
+  test("formats kilobytes and megabytes", () => {
+    expect(formatSize(50000)).toBe("50.00 kB");
+    expect(formatSize(1500000)).toBe("1.50 MB");
+  });
+});

--- a/tests/lib/performance/report.test.js
+++ b/tests/lib/performance/report.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import { generatePerformanceReport } from "../../../lib/performance/report.js";
+
+describe("generatePerformanceReport", () => {
+  test("renders a summary, evaluation table, and per-category breakdown", () => {
+    const result = {
+      measurement: {
+        categories: {
+          "global-css": {
+            files: [
+              { path: "/project/a.css", raw: 10000, gzip: 3000, brotli: 2500 },
+            ],
+            totals: { raw: 10000, gzip: 3000, brotli: 2500 },
+          },
+          "global-js": {
+            files: [],
+            totals: { raw: 0, gzip: 0, brotli: 0 },
+          },
+        },
+        totals: { raw: 10000, gzip: 3000, brotli: 2500 },
+      },
+      evaluations: [
+        {
+          category: "global-css",
+          key: "total",
+          label: "Global CSS",
+          actual: 3000,
+          budget: 35000,
+          status: "ok",
+          ratio: 0.08,
+        },
+        {
+          category: "global-js",
+          key: "total",
+          label: "Global JS",
+          actual: 0,
+          budget: 200000,
+          status: "ok",
+          ratio: 0,
+        },
+      ],
+      compression: "gzip",
+      summary: { ok: 2, warn: 0, exceed: 0, unbudgeted: 0 },
+    };
+
+    const md = generatePerformanceReport(result, { cwd: "/project" });
+
+    expect(md).toContain("# Performance Budget Report");
+    expect(md).toContain("**Compression:** Gzip");
+    expect(md).toContain("**OK:** 2");
+    expect(md).toContain("| global-css | Total | 3.00 kB | 35.00 kB | OK |");
+    expect(md).toContain("## global-css");
+    expect(md).toContain("| a.css | 10.00 kB | 3.00 kB | 2.50 kB |");
+    // Categories with no files should not generate a detail section.
+    expect(md).not.toContain("## global-js");
+  });
+});

--- a/tests/lib/performance/routes.integration.test.js
+++ b/tests/lib/performance/routes.integration.test.js
@@ -1,0 +1,61 @@
+import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import init from "../../../lib/index.js";
+
+let server;
+let port;
+
+beforeAll(async () => {
+  process.env.MIYAGI_JS_API = true;
+  global.app = await init("api");
+
+  await new Promise((resolve) => {
+    server = global.app.listen(0, () => {
+      port = server.address().port;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  process.env.MIYAGI_JS_API = false;
+  if (server) await new Promise((resolve) => server.close(resolve));
+});
+
+describe("performance routes (dev mode)", () => {
+  test("GET /api/performance returns JSON with expected shape", async () => {
+    const res = await fetch(`http://localhost:${port}/api/performance`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/json/);
+
+    const body = await res.json();
+    expect(body).toHaveProperty("measurement");
+    expect(body).toHaveProperty("evaluations");
+    expect(body).toHaveProperty("compression");
+    expect(body).toHaveProperty("summary");
+    expect(body.summary).toEqual(
+      expect.objectContaining({
+        ok: expect.any(Number),
+        warn: expect.any(Number),
+        exceed: expect.any(Number),
+        unbudgeted: expect.any(Number),
+      }),
+    );
+  });
+
+  test("GET /iframe/performance renders the panel", async () => {
+    const res = await fetch(`http://localhost:${port}/iframe/performance`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain("Performance budget");
+    expect(html).toContain("PerformanceTable");
+  });
+
+  test("GET /performance renders the main chrome pointed at the iframe", async () => {
+    const res = await fetch(`http://localhost:${port}/performance`);
+    expect(res.status).toBe(200);
+
+    const html = await res.text();
+    expect(html).toContain('src="/iframe/performance"');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a performance budget feature that tracks asset byte sizes (raw/gzip/brotli) against configurable limits
- Defaults sourced from web.dev's "Your First Performance Budget" Slow 4G tier (35 kB CSS, 200 kB JS, 30 kB HTML/page, 30 kB fonts, 50 kB images — all gzip)
- Zero new dependencies — uses Node's built-in `zlib` for compression measurement

## Surfaces

- **`miyagi budget` CLI** — on-demand check with `--fail`, `--json`, `--compression`, `--list-all-pages`, `--build-folder`, `--output` flags
- **Build-time** — report written to `<buildFolder>/performance-report.md` alongside `output.json`; warn-only by default, opt-in fail via `performance.report.failOnExceed`
- **Dev-server** — Performance panel in the sidebar menu (dev-mode only), `/api/performance` JSON endpoint
- **JS API** — `getPerformance()` export from `@miyagi/core/api`

## Categories measured

- Global CSS (`config.assets.css` + `config.assets.shared.css`)
- Global JS (`config.assets.js` + `config.assets.shared.js`)
- Asset folders (`config.assets.folder[]`) — aggregated per folder
- Rendered HTML pages (build-time only, from `output.json`)
- Per-component budgets reserved in config shape for follow-up

## Follow-up issues filed

- #76 — Consolidate raw CSS values into a design token system
- #77 — Consider a shared CLI output helper for table formatting
- #78 — Use Valibot schemas for performance module typedefs
- #79 — Extract shared markdown report utilities from report writers

## Test plan

- [ ] `pnpm lint` — clean
- [ ] `pnpm test` — 219 tests pass (24 new across 5 test files)
- [ ] `miyagi budget` prints evaluation table
- [ ] `miyagi budget --json` emits parseable JSON
- [ ] `miyagi budget --fail` exits non-zero when budget exceeded
- [ ] `miyagi build` writes `performance-report.md` inside build folder
- [ ] Dev server: `/performance`, `/iframe/performance`, `/api/performance` all respond
- [ ] Performance menu item only appears in dev mode, not in build output