### PR TITLE
fix(performance): resolve component files relative to componentsFolder

### DIFF
--- a/lib/cli/perf.js
+++ b/lib/cli/perf.js
@@ -59,6 +59,7 @@ export default async function perfCli(args) {
 
   const result = await runPerformance({
     cwd,
+    componentsFolder: global.config.components.folder,
     compression: args.compression,
     warnRatio: warnRatioOverride,
     render: renderPageHtml,

--- a/lib/init/router.js
+++ b/lib/init/router.js
@@ -68,6 +68,7 @@ export default function Router() {
   if (!global.config.isBuild) {
     attachPerformanceRoutes(global.app, {
       cwd: process.cwd(),
+      componentsFolder: global.config.components.folder,
       render: renderPageHtml,
     });
   }

--- a/lib/performance/component.js
+++ b/lib/performance/component.js
@@ -55,6 +55,7 @@ function resolveImportGraph(entryPath) {
  * 50 kB util shows the real reachable size, not just the entry file.
  * @param {{
  *   cwd: string,
+ *   componentsFolder: string,
  *   componentPath: string,
  *   entry: { css?: { budget?: string }, js?: { budget?: string } },
  *   compression: "raw"|"gzip"|"brotli",
@@ -64,12 +65,13 @@ function resolveImportGraph(entryPath) {
  */
 export function measureComponent({
   cwd,
+  componentsFolder = "",
   componentPath,
   entry,
   compression,
   warnRatio,
 }) {
-  const folder = path.join(cwd, componentPath);
+  const folder = path.join(cwd, componentsFolder, componentPath);
   const componentName = path.basename(componentPath);
   const cssPath = path.join(folder, `${componentName}.css`);
   const jsPath = path.join(folder, `${componentName}.js`);

--- a/lib/performance/index.js
+++ b/lib/performance/index.js
@@ -47,6 +47,7 @@ function tally(statuses) {
  * declared page variation.
  * @param {{
  *   cwd?: string,
+ *   componentsFolder?: string,
  *   compression?: "raw"|"gzip"|"brotli",
  *   warnRatio?: number,
  *   render?: (templatePath: string, variation: string) => Promise<string>,
@@ -60,6 +61,7 @@ export async function runPerformance(options = {}) {
   }
 
   const cwd = options.cwd ?? process.cwd();
+  const componentsFolder = options.componentsFolder ?? "";
   const compression = options.compression ?? config.compression;
   const warnRatio = options.warnRatio ?? config.warnRatio;
 
@@ -68,6 +70,7 @@ export async function runPerformance(options = {}) {
   for (const [componentPath, entry] of Object.entries(config.components)) {
     const measurement = measureComponent({
       cwd,
+      componentsFolder,
       componentPath,
       entry,
       compression,

--- a/lib/performance/routes.js
+++ b/lib/performance/routes.js
@@ -19,6 +19,7 @@ import { runPerformance } from "./index.js";
  * @param {object} app - Express app
  * @param {{
  *   cwd: string,
+ *   componentsFolder?: string,
  *   render?: (templatePath: string, variation: string) => Promise<string>,
  * }} options
  * @returns {boolean} true when the config file exists at registration time
@@ -28,6 +29,7 @@ export function attachPerformanceRoutes(app, options) {
     try {
       const result = await runPerformance({
         cwd: options.cwd,
+        componentsFolder: options.componentsFolder,
         render: options.render,
       });
       if (!result.enabled) {

--- a/lib/render/views/iframe/component.js
+++ b/lib/render/views/iframe/component.js
@@ -250,7 +250,10 @@ async function renderVariations({
 
       let perfSection;
       try {
-        const perfResult = await runPerformance({ cwd: process.cwd() });
+        const perfResult = await runPerformance({
+          cwd: process.cwd(),
+          componentsFolder: global.config.components.folder,
+        });
         perfSection = buildComponentPerfSection(
           perfResult,
           component.paths.dir.short,

--- a/lib/render/views/main/component.js
+++ b/lib/render/views/main/component.js
@@ -45,6 +45,7 @@ export default async function renderMainComponent({
     try {
       const perfResult = await runPerformance({
         cwd: process.cwd(),
+        componentsFolder: global.config.components.folder,
         render: renderPageHtml,
       });
       perfBanner = buildPagePerfBanner(

--- a/tests/lib/cli/perf.test.js
+++ b/tests/lib/cli/perf.test.js
@@ -76,7 +76,7 @@ describe("miyagi perf CLI", () => {
       default: async () => ({}),
     }));
     vi.doMock("../../../lib/config.js", () => ({
-      default: async () => ({}),
+      default: async () => ({ components: { folder: "" } }),
     }));
 
     const perfCli = await importCliPerf();
@@ -106,7 +106,7 @@ describe("miyagi perf CLI", () => {
     );
 
     vi.doMock("../../../lib/index.js", () => ({ default: async () => ({}) }));
-    vi.doMock("../../../lib/config.js", () => ({ default: async () => ({}) }));
+    vi.doMock("../../../lib/config.js", () => ({ default: async () => ({ components: { folder: "" } }) }));
 
     const perfCli = await importCliPerf();
     const result = await perfCli({ fail: true });
@@ -126,7 +126,7 @@ describe("miyagi perf CLI", () => {
     );
 
     vi.doMock("../../../lib/index.js", () => ({ default: async () => ({}) }));
-    vi.doMock("../../../lib/config.js", () => ({ default: async () => ({}) }));
+    vi.doMock("../../../lib/config.js", () => ({ default: async () => ({ components: { folder: "" } }) }));
 
     const perfCli = await importCliPerf();
     await perfCli({ json: true, compression: "brotli" });

--- a/tests/lib/performance/component.test.js
+++ b/tests/lib/performance/component.test.js
@@ -415,4 +415,28 @@ describe("measureComponent", () => {
     expect(result.css.budget).toBe(5000);
     expect(result.js.budget).toBe(10000);
   });
+
+  test("resolves files under componentsFolder when short componentPath is used", () => {
+    const cwd = makeTempCwd();
+    // Mirror the real layout: files live at <cwd>/<componentsFolder>/<componentPath>/
+    // but the config key and dir.short are relative to componentsFolder only.
+    writeComponent(cwd, "src/components/elements/button", {
+      "button.css": ".btn { color: red; }",
+      "button.js": "export const x = 1;",
+    });
+
+    const result = measureComponent({
+      cwd,
+      componentsFolder: "src/components",
+      componentPath: "elements/button",
+      entry: { css: { budget: "5 kB" }, js: { budget: "10 kB" } },
+      compression: "raw",
+      warnRatio: 0.8,
+    });
+
+    expect(result.css.bytes).toBe(".btn { color: red; }".length);
+    expect(result.js.bytes).toBe("export const x = 1;".length);
+    expect(result.css.status).toBe("ok");
+    expect(result.js.status).toBe("ok");
+  });
 });

--- a/tests/lib/performance/run.test.js
+++ b/tests/lib/performance/run.test.js
@@ -181,6 +181,36 @@ describe("runPerformance", () => {
     expect(result.summary.pages.ok).toBe(0);
   });
 
+  test("resolves component files when componentsFolder splits the path from the config key", async () => {
+    // Regression test: config keys (and dir.short) are relative to componentsFolder,
+    // but files live at <cwd>/<componentsFolder>/<componentPath>. Without forwarding
+    // componentsFolder the measurement resolves the wrong path and returns 0 B.
+    const cwd = makeTempCwd();
+    writeFile(cwd, "src/components/elements/button/button.css", "x".repeat(800));
+    writeFile(cwd, "src/components/elements/button/button.js", "y".repeat(200));
+    writeFile(cwd, "miyagi.performance.json", JSON.stringify({
+      compression: "raw",
+      components: {
+        "elements/button": {
+          css: { budget: "5 kB" },
+          js: { budget: "10 kB" },
+        },
+      },
+    }));
+
+    const result = await runPerformance({
+      cwd,
+      componentsFolder: "src/components",
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.components).toHaveLength(1);
+    expect(result.components[0].css.bytes).toBe(800);
+    expect(result.components[0].js.bytes).toBe(200);
+    expect(result.components[0].css.status).toBe("ok");
+    expect(result.components[0].js.status).toBe("ok");
+  });
+
   test("pages whose components are missing from measurements record errors", async () => {
     const cwd = makeTempCwd();
     writeFile(cwd, "components/atoms/button/button.css", "x");


### PR DESCRIPTION
## Summary

- Component asset sizes always reported as `0 B` because `measureComponent` joined `cwd` directly with the short `componentPath` (e.g. `elements/button`), missing the `components.folder` prefix (e.g. `src/components`) — so the resolved path never existed on disk
- Added a `componentsFolder` parameter to `measureComponent` and `runPerformance` (defaults to `""` for backwards compatibility) and passes `global.config.components.folder` from all call sites
- Added regression tests that explicitly model the real split between `componentsFolder` and the short component path, so this class of bug cannot silently pass tests again

## Test plan

- [ ] `npx vitest run tests/lib/performance/component.test.js` — new test `resolves files under componentsFolder when short componentPath is used` passes
- [ ] `npx vitest run tests/lib/performance/run.test.js` — new test `resolves component files when componentsFolder splits the path from the config key` passes
- [ ] All other performance tests continue to pass
- [ ] In a real miyagi project with `components.folder: "src/components"` and `miyagi.performance.json` using short keys like `"elements/button"`, the overview now shows actual file sizes instead of `0 B`

🤖 Generated with assistance from [Claude Code](https://claude.com/claude-code)