### PR TITLE
[codex] Apply extension config before processing

### DIFF
--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -78,6 +78,7 @@ export function applyExtensionConfig(config) {
 
     if (extensionConfig && typeof extensionConfig === "object") {
       nextConfig = deepMerge(nextConfig, extensionConfig);
+      nextConfig.extensions = normalizeExtensions(nextConfig.extensions);
     }
   }
 

--- a/lib/extensions.js
+++ b/lib/extensions.js
@@ -1,0 +1,85 @@
+import deepMerge from "deepmerge";
+
+/**
+ * @returns {object} default extension options
+ */
+function getDefaultExtensionOptions() {
+  return { locales: {} };
+}
+
+/**
+ * @typedef {object} ExtensionEntry
+ * @property {object} extension - The plugin or extension module.
+ * @property {object} options - Options passed to the plugin.
+ */
+
+/**
+ * @param {object|Array} entry
+ * @returns {ExtensionEntry|null}
+ */
+export function normalizeExtensionEntry(entry) {
+  if (!entry) {
+    return null;
+  }
+
+  if (Array.isArray(entry)) {
+    return {
+      extension: entry[0],
+      options: entry[1] || getDefaultExtensionOptions(),
+    };
+  }
+
+  if (entry.plugin || entry.extension) {
+    return {
+      extension: entry.plugin || entry.extension,
+      options: entry.options || getDefaultExtensionOptions(),
+    };
+  }
+
+  return {
+    extension: entry,
+    options: getDefaultExtensionOptions(),
+  };
+}
+
+/**
+ * @param {Array} entries
+ * @returns {ExtensionEntry[]}
+ */
+export function normalizeExtensions(entries = []) {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+
+  return entries
+    .map(normalizeExtensionEntry)
+    .filter((entry) => entry?.extension && typeof entry.extension === "object");
+}
+
+/**
+ * @param {object} config
+ * @returns {object}
+ */
+export function applyExtensionConfig(config) {
+  let nextConfig = {
+    ...config,
+    extensions: normalizeExtensions(config.extensions),
+  };
+
+  for (const { extension, options } of nextConfig.extensions) {
+    if (typeof extension.configure !== "function") {
+      continue;
+    }
+
+    const extensionConfig = extension.configure({
+      config: nextConfig,
+      options,
+    });
+
+    if (extensionConfig && typeof extensionConfig === "object") {
+      nextConfig = deepMerge(nextConfig, extensionConfig);
+    }
+  }
+
+  return nextConfig;
+}

--- a/lib/init/config.js
+++ b/lib/init/config.js
@@ -10,6 +10,7 @@ import { t, available as langAvailable } from "../i18n/index.js";
 import { LINT_LOG_LEVELS } from "../constants/lint-log-levels.js";
 import fs from "fs";
 import path from "path";
+import { applyExtensionConfig } from "../extensions.js";
 
 const { defaultUserConfig } = appConfig;
 
@@ -386,7 +387,7 @@ function getAssetFoldersArray(strOrArrOrObj) {
  * @returns {object} the user configuration merged with the default configuration
  */
 export default (userConfig = {}) => {
-  const config = { ...userConfig };
+  const config = applyExtensionConfig({ ...userConfig });
 
   if (config.build) {
     if (config.build.basePath) {

--- a/lib/init/watcher.js
+++ b/lib/init/watcher.js
@@ -204,11 +204,18 @@ function getExtensionSources(watchConfig) {
   for (const { extension, options } of normalizeExtensions(
     global.config.extensions,
   )) {
-    if (!extension.extendWatcher) {
+    if (typeof extension.extendWatcher !== "function") {
       continue;
     }
 
-    const extensionWatch = extension.extendWatcher(options);
+    let extensionWatch;
+    try {
+      extensionWatch = extension.extendWatcher(options);
+    } catch (error) {
+      log("error", error);
+      continue;
+    }
+
     if (!extensionWatch?.folder || !extensionWatch?.lang) {
       continue;
     }
@@ -337,8 +344,14 @@ async function handleFileChange(events) {
   for (const { extension, options } of normalizeExtensions(
     global.config.extensions,
   )) {
-    if (extension.callbacks?.fileChanged) {
+    if (typeof extension.callbacks?.fileChanged !== "function") {
+      continue;
+    }
+
+    try {
       await extension.callbacks.fileChanged(options);
+    } catch (error) {
+      log("error", error);
     }
   }
 

--- a/lib/init/watcher.js
+++ b/lib/init/watcher.js
@@ -18,6 +18,7 @@ import { t } from "../i18n/index.js";
 import setEngines from "./engines.js";
 import setStatic from "./static.js";
 import setViews from "./views.js";
+import { normalizeExtensions } from "../extensions.js";
 
 const SOCKET_PATH = "/__miyagi_ws";
 const sockets = new Set();
@@ -200,16 +201,14 @@ function printWatchReport(report, watchConfig) {
 function getExtensionSources(watchConfig) {
   const extensionSources = [];
 
-  for (const extension of global.config.extensions) {
-    const ext = Array.isArray(extension) ? extension[0] : extension;
-    const opts =
-      Array.isArray(extension) && extension[1] ? extension[1] : { locales: {} };
-
-    if (!ext.extendWatcher) {
+  for (const { extension, options } of normalizeExtensions(
+    global.config.extensions,
+  )) {
+    if (!extension.extendWatcher) {
       continue;
     }
 
-    const extensionWatch = ext.extendWatcher(opts);
+    const extensionWatch = extension.extendWatcher(options);
     if (!extensionWatch?.folder || !extensionWatch?.lang) {
       continue;
     }
@@ -335,13 +334,11 @@ function pathExistsAsDirectory(changedPath) {
  * @returns {Promise<void>}
  */
 async function handleFileChange(events) {
-  for (const extension of global.config.extensions) {
-    const ext = Array.isArray(extension) ? extension[0] : extension;
-    const opts =
-      Array.isArray(extension) && extension[1] ? extension[1] : { locales: {} };
-
-    if (ext.callbacks?.fileChanged) {
-      await ext.callbacks.fileChanged(opts);
+  for (const { extension, options } of normalizeExtensions(
+    global.config.extensions,
+  )) {
+    if (extension.callbacks?.fileChanged) {
+      await extension.callbacks.fileChanged(options);
     }
   }
 

--- a/lib/render/helpers.js
+++ b/lib/render/helpers.js
@@ -5,6 +5,7 @@
 
 import path from "path";
 import anymatch from "anymatch";
+import { normalizeExtensions } from "../extensions.js";
 
 /**
  * @param {object} config - the user configuration object
@@ -13,17 +14,13 @@ import anymatch from "anymatch";
  * @returns {Promise<object>} the extended data object
  */
 export const extendTemplateData = async (config, data, component) => {
-  for (const extension of config.extensions) {
-    if (extension) {
-      const ext = Array.isArray(extension) ? extension[0] : extension;
-
-      if (ext.extendTemplateData) {
-        data = await ext.extendTemplateData(
-          path.join(config.components.folder, component.paths.tpl.short),
-          {},
-          data,
-        );
-      }
+  for (const { extension } of normalizeExtensions(config.extensions)) {
+    if (extension.extendTemplateData) {
+      data = await extension.extendTemplateData(
+        path.join(config.components.folder, component.paths.tpl.short),
+        {},
+        data,
+      );
     }
   }
 

--- a/lib/render/helpers.js
+++ b/lib/render/helpers.js
@@ -15,7 +15,7 @@ import { normalizeExtensions } from "../extensions.js";
  */
 export const extendTemplateData = async (config, data, component) => {
   for (const { extension } of normalizeExtensions(config.extensions)) {
-    if (extension.extendTemplateData) {
+    if (typeof extension.extendTemplateData === "function") {
       data = await extension.extendTemplateData(
         path.join(config.components.folder, component.paths.tpl.short),
         {},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3576,10 +3576,6 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   pre-commit@2.0.0:
     resolution: {integrity: sha512-gStVX9Yji5PjN4Yl1/4fSc9LPzwdGkkiSgarug873vfatIH47WIXPa+rcE8FK9JrbsMGuZji2Ih3V+G+Oa8eww==}
     engines: {node: '>=16.13.0'}
@@ -8474,12 +8470,6 @@ snapshots:
   postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/starlight/astro.config.mjs
+++ b/starlight/astro.config.mjs
@@ -107,6 +107,10 @@ export default defineConfig({
             },
           ],
         },
+        {
+          label: "Architecture",
+          items: [{ label: "Plugin API", slug: "architecture/plugin-api" }],
+        },
         { label: "JavaScript API", slug: "javascript-api" },
         {
           label: "How-To Guides",

--- a/starlight/src/content/docs/architecture/plugin-api.md
+++ b/starlight/src/content/docs/architecture/plugin-api.md
@@ -1,0 +1,166 @@
+---
+title: "Plugin API"
+---
+
+Miyagi's plugin API is experimental in v4. It exists to keep the default core lightweight and web-platform-first while allowing project or ecosystem packages to add behavior for Twig, Drupal, Web Components, or other integrations.
+
+Plugins are plain JavaScript objects provided through the [`extensions` configuration option](/configuration/options/#extensions). They can be local modules or npm packages imported by the project's `.miyagi.js` or `.miyagi.mjs` file.
+
+## Goals
+
+- Keep the no-plugin path simple: a config file, component folders, mock data, assets, and a project-owned `engine.render` function.
+- Move ecosystem-specific behavior behind explicit extension points before adding more engine-specific code to core.
+- Preserve existing v4 extension tuples while introducing a clearer object shape for new plugins.
+- Start with an experimental contract, then version the API after the Drupal and Twig migration paths are proven.
+
+## Plugin Shape
+
+```js
+export default {
+  name: "miyagi-example-plugin",
+
+  configure({ config, options }) {
+    return {
+      watch: {
+        sources: [
+          {
+            id: "example-plugin",
+            type: "dir",
+            path: options.folder,
+            optional: true,
+          },
+        ],
+      },
+    };
+  },
+
+  async extendTemplateData(templatePath, templateOptions, data) {
+    return {
+      ...data,
+      plugin: {
+        templatePath,
+      },
+    };
+  },
+
+  callbacks: {
+    async fileChanged(options) {
+      options.cache?.clear?.();
+    },
+  },
+};
+```
+
+Projects can register a plugin directly or with the object syntax when options are needed:
+
+```js
+import examplePlugin from "miyagi-example-plugin";
+
+export default {
+  extensions: [
+    examplePlugin,
+    {
+      plugin: examplePlugin,
+      options: {
+        folder: "fixtures",
+      },
+    },
+  ],
+};
+```
+
+## Extension Points
+
+### `configure({ config, options })`
+
+Runs while Miyagi processes config. Return a partial Miyagi config object. The returned object is merged into the project config and then normalized by the ordinary config pipeline, so paths, asset arrays, watch sources, and legacy compatibility rules still behave the same way.
+
+Use this for:
+
+- adding `watch.sources`
+- adding shared or global assets
+- setting file names or extensions
+- contributing config defaults for a plugin
+
+Do not use this to start servers, read component state, or mutate global state. Those surfaces are not available yet.
+
+### `extendTemplateData(templatePath, templateOptions, data)`
+
+Runs before component data is passed to the project render function. Return the data object to render. This is the right place for engine helpers that need to be visible in templates.
+
+### `extendWatcher(options)`
+
+Deprecated legacy watcher extension point. It returns a folder and language pair that Miyagi watches as an optional directory.
+
+Existing v4 extensions can keep using it during the compatibility window, but new plugins should use `configure()` with `watch.sources` because it uses the same explicit watch source model as core.
+
+### `callbacks.fileChanged(options)`
+
+Runs after watched files change and before Miyagi updates state and reloads previews. Use it for small cache invalidation work. Long-running rebuilds should stay outside this callback until the lifecycle API is expanded.
+
+## What Stays In Core
+
+- Component discovery from ordinary folders
+- Mock data loading, variants, references, and schema validation
+- Iframe rendering and the project-owned `engine.render` contract
+- Static build generation
+- HTML validation and performance reporting
+- Asset isolation through `$assets`, `assets.shared`, and `assets.isolateComponents`
+- Core CLI/API commands for generic component workflows
+
+## What Should Move To Plugins
+
+- Drupal `*.libraries.yml` resolution and dependency mapping
+- Twig/Twing-specific helpers that are not required by Miyagi's internal UI
+- Framework-specific asset discovery
+- Engine-specific validator rules
+- Documentation, examples, or commands for a single ecosystem
+
+## Drupal Example
+
+The Drupal asset resolver is the first planned migration case and is tracked in [#134](https://github.com/schalkneethling/miyagi/issues/134). The eventual plugin shape should look like this from a user's config:
+
+```js
+import drupalAssetsPlugin from "@miyagi/drupal-assets";
+
+export default {
+  extensions: [
+    {
+      plugin: drupalAssetsPlugin,
+      options: {
+        libraries: "mytheme.libraries.yml",
+        ignorePrefixes: ["core", "drupal"],
+      },
+    },
+  ],
+};
+```
+
+Implementation details for extracting the current core resolver belong in the follow-up issue rather than this API reference. Twig/Twing boundary work is tracked separately in [#135](https://github.com/schalkneethling/miyagi/issues/135), and the broader migration documentation is tracked in [#138](https://github.com/schalkneethling/miyagi/issues/138).
+
+## Backwards Compatibility
+
+Existing v4 projects can continue to use:
+
+```js
+extensions: [[plugin, options]]
+```
+
+This tuple form is deprecated. It remains supported for existing v4 projects, but new code should use the object form below.
+
+New projects should prefer:
+
+```js
+extensions: [{ plugin, options }]
+```
+
+The API is experimental. Plugin authors should avoid depending on internal `global.*` state unless a documented hook passes the needed value.
+
+## Stabilization Criteria
+
+The plugin API should become versioned only after:
+
+- Drupal asset resolution has moved behind the plugin boundary.
+- Twig-specific user-component helpers are separated from Miyagi's internal UI rendering.
+- A Web Components example works without Twig or Drupal plugins.
+- At least one plugin contributes config, watcher sources, and template data in tests.

--- a/starlight/src/content/docs/configuration/options.md
+++ b/starlight/src/content/docs/configuration/options.md
@@ -211,6 +211,40 @@ The render function for your templates. The function will be called with an obje
 default: `[]`<br>
 type: `array`
 
+Experimental plugin entry points for ecosystem-specific behavior. Plugins can be local modules or npm packages imported by your `.miyagi.js` or `.miyagi.mjs` file.
+
+```js
+import myPlugin from "miyagi-example-plugin";
+
+export default {
+  extensions: [
+    {
+      plugin: myPlugin,
+      options: {
+        folder: "fixtures",
+      },
+    },
+  ],
+};
+```
+
+Miyagi also supports the older tuple form for existing v4 projects, but it is deprecated. New code should use `{ plugin, options }`.
+
+```js
+export default {
+  extensions: [[myPlugin, { folder: "fixtures" }]],
+};
+```
+
+Supported hooks are:
+
+- `configure({ config, options })`: return a partial Miyagi config object to merge before normal config processing.
+- `extendTemplateData(templatePath, templateOptions, data)`: return template data before rendering.
+- `extendWatcher(options)`: deprecated legacy helper for adding optional watcher folders.
+- `callbacks.fileChanged(options)`: run cache invalidation or other small work after a watched file changes.
+
+See [Plugin API](/architecture/plugin-api/) for the current experimental contract and migration guidance.
+
 ## `files`
 
 _This is the configuration for your actual component files._

--- a/tests/lib/extensions.test.js
+++ b/tests/lib/extensions.test.js
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import {
+  applyExtensionConfig,
+  normalizeExtensionEntry,
+  normalizeExtensions,
+} from "../../lib/extensions.js";
+
+describe("extension helpers", () => {
+  test("normalizes a direct extension object", () => {
+    const extension = { name: "direct-extension" };
+
+    expect(normalizeExtensionEntry(extension)).toStrictEqual({
+      extension,
+      options: { locales: {} },
+    });
+  });
+
+  test("normalizes a legacy tuple entry", () => {
+    const extension = { name: "tuple-extension" };
+
+    expect(normalizeExtensionEntry([extension, { locale: "en" }])).toStrictEqual(
+      {
+        extension,
+        options: { locale: "en" },
+      },
+    );
+  });
+
+  test("normalizes a named plugin entry", () => {
+    const extension = { name: "object-extension" };
+
+    expect(
+      normalizeExtensionEntry({
+        plugin: extension,
+        options: { assetRoot: "dist" },
+      }),
+    ).toStrictEqual({
+      extension,
+      options: { assetRoot: "dist" },
+    });
+  });
+
+  test("filters invalid extension entries", () => {
+    expect(normalizeExtensions([null, false, "plugin-name"])).toStrictEqual([]);
+  });
+
+  test("applies extension configuration hooks", () => {
+    const extension = {
+      configure({ options }) {
+        return {
+          assets: {
+            shared: {
+              css: [options.cssFile],
+            },
+          },
+          watch: {
+            sources: [
+              {
+                id: "extension-fixtures",
+                type: "dir",
+                path: "./fixtures/",
+              },
+            ],
+          },
+        };
+      },
+    };
+
+    expect(
+      applyExtensionConfig({
+        extensions: [{ plugin: extension, options: { cssFile: "tokens.css" } }],
+      }),
+    ).toStrictEqual({
+      extensions: [{ extension, options: { cssFile: "tokens.css" } }],
+      assets: {
+        shared: {
+          css: ["tokens.css"],
+        },
+      },
+      watch: {
+        sources: [
+          {
+            id: "extension-fixtures",
+            type: "dir",
+            path: "./fixtures/",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/tests/lib/extensions.test.js
+++ b/tests/lib/extensions.test.js
@@ -88,4 +88,37 @@ describe("extension helpers", () => {
       },
     });
   });
+
+  test("normalizes extensions returned by configuration hooks", () => {
+    const configuredExtension = {
+      name: "configured-extension",
+    };
+    const extension = {
+      configure() {
+        return {
+          extensions: [
+            {
+              plugin: configuredExtension,
+              options: { enabled: true },
+            },
+          ],
+        };
+      },
+    };
+
+    expect(
+      applyExtensionConfig({
+        extensions: [extension],
+      }).extensions,
+    ).toStrictEqual([
+      {
+        extension,
+        options: { locales: {} },
+      },
+      {
+        extension: configuredExtension,
+        options: { enabled: true },
+      },
+    ]);
+  });
 });

--- a/tests/lib/init/config.test.js
+++ b/tests/lib/init/config.test.js
@@ -149,4 +149,64 @@ describe("config processing", () => {
       expect(config.assets.isolateComponents).toBe(false);
     });
   });
+
+  describe("extensions", () => {
+    test("normalizes legacy extension tuples and options", () => {
+      const extension = { name: "legacy-extension" };
+      const config = getConfig({
+        extensions: [[extension, { locale: "en" }]],
+      });
+
+      expect(config.extensions).toStrictEqual([
+        {
+          extension,
+          options: { locale: "en" },
+        },
+      ]);
+    });
+
+    test("applies extension config before normal config processing", () => {
+      const extension = {
+        configure() {
+          return {
+            assets: {
+              shared: {
+                css: ["./tokens.css"],
+              },
+            },
+            watch: {
+              sources: [
+                {
+                  id: "extension-docs",
+                  type: "dir",
+                  path: "./extension-docs/",
+                },
+              ],
+            },
+          };
+        },
+      };
+
+      const config = getConfig({
+        extensions: [extension],
+      });
+
+      expect(config.assets.shared.css).toStrictEqual(["tokens.css"]);
+      expect(config.extensions).toStrictEqual([
+        {
+          extension,
+          options: { locales: {} },
+        },
+      ]);
+      expect(config.watch.sources).toStrictEqual([
+        {
+          id: "extension-docs",
+          type: "dir",
+          path: "extension-docs",
+          recursive: true,
+          optional: false,
+        },
+      ]);
+    });
+  });
 });

--- a/tests/lib/init/watcher.test.js
+++ b/tests/lib/init/watcher.test.js
@@ -160,6 +160,21 @@ describe("Watcher", () => {
     expect(consoleInfoSpy).toHaveBeenCalled();
   });
 
+  test("continues when extension watcher hooks throw", () => {
+    const error = new Error("watcher extension failed");
+    global.config.extensions = [
+      {
+        extendWatcher() {
+          throw error;
+        },
+      },
+    ];
+
+    expect(() => Watcher(mockServer)).not.toThrow();
+    expect(mockLogger).toHaveBeenCalledWith("error", error);
+    expect(watchMock).toHaveBeenCalledTimes(1);
+  });
+
   test("coalesces repeated events for same path", async () => {
     Watcher(mockServer);
 
@@ -181,6 +196,27 @@ describe("Watcher", () => {
       menu: true,
       partials: true,
     });
+  });
+
+  test("continues when extension file-change callbacks throw", async () => {
+    const error = new Error("file changed extension failed");
+    global.config.extensions = [
+      {
+        callbacks: {
+          async fileChanged() {
+            throw error;
+          },
+        },
+      },
+    ];
+
+    Watcher(mockServer);
+
+    chokidarOnHandlers.all("change", "lib/example.txt");
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(mockLogger).toHaveBeenCalledWith("error", error);
+    expect(mockSetState).toHaveBeenCalledTimes(1);
   });
 
   test("prints resolved source list only when debug.logResolvedSources is enabled", () => {

--- a/tests/lib/render/helpers.test.js
+++ b/tests/lib/render/helpers.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { extendTemplateData } from "../../../lib/render/helpers.js";
+
+describe("render helpers", () => {
+  test("ignores non-callable extension template data hooks", async () => {
+    const data = { title: "Button" };
+
+    await expect(
+      extendTemplateData(
+        {
+          components: { folder: "src" },
+          extensions: [{ extendTemplateData: true }],
+        },
+        data,
+        {
+          paths: {
+            tpl: {
+              short: "button/button.twig",
+            },
+          },
+        },
+      ),
+    ).resolves.toBe(data);
+  });
+});


### PR DESCRIPTION
## Summary
- Add shared extension normalization helpers and support configure() hooks before ordinary config processing.
- Reuse normalized extension entries in watcher and template-data extension handling.
- Document the experimental plugin API, deprecated legacy extension surfaces, and the core/plugin boundary.

## Why
Issue #133 calls for a first-class plugin API boundary so ecosystem-specific behavior can move out of core without weakening the simple default setup.

## Validation
- pnpm test
- npx eslint lib/extensions.js lib/init/config.js lib/init/watcher.js lib/render/helpers.js
- pnpm run docs:build (rerun outside sandbox after sandbox DNS failure for localhost)
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an experimental plugin/extension system with consistent entry normalization and configuration application across the core workflow.
  * Extensions can now contribute configuration, template data, and watcher behavior using the documented hook contract.

* **Bug Fixes**
  * Improved resilience: extension failures in watcher setup or file-change callbacks are caught and logged without stopping the watcher.

* **Documentation**
  * Added Plugin API and extensions configuration documentation, including example syntax and migration guidance.

* **Tests**
  * Expanded coverage for normalization, configuration integration, watcher failure handling, and render helper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->